### PR TITLE
Fix typo to close div tag in Taxii master template.

### DIFF
--- a/taxii_service/templates/taxii_service_master_tab.html
+++ b/taxii_service/templates/taxii_service_master_tab.html
@@ -90,4 +90,4 @@
 		<br/>
 		<button class="back_to_cfg taxii_btn">Back</button>
 	</section>
-<div>
+</div>


### PR DESCRIPTION
All my tab contents disappeared!  Found this to be the culprit.
