### PR TITLE
Cuckoo fixups

### DIFF
--- a/cuckoo_service/__init__.py
+++ b/cuckoo_service/__init__.py
@@ -22,7 +22,7 @@ class CuckooService(Service):
     """
 
     name = 'cuckoo'
-    version = '1.0.1a1'
+    version = '1.0.1'
     type_ = Service.TYPE_CUSTOM
     supported_types = ['Sample']
     default_config = [


### PR DESCRIPTION
Add some error checking to make the service a bit more robust:
- Don't try to process a PCAP file if there was a problem fetching it from the cuckoo server.
- If running multiple analyses, don't have the entire service quit if there is an error in processing one of them.

These should not cause any change in behavior in a "normal" run, only when unexpected errors occur.

Also bump the service version so it's no longer "alpha".
