### PR TITLE
(Cuckoo) Allow for caps in machine names

### DIFF
--- a/cuckoo_service/__init__.py
+++ b/cuckoo_service/__init__.py
@@ -137,8 +137,8 @@ class CuckooService(Service):
 
         tasks = {}
 
-        machine = self.config.get('machine', "").lower()
-        if machine == "all":
+        machine = self.config.get('machine', "")
+        if machine.lower() == "all":
             # Submit a new task with otherwise the same info to each machine
             for each in self.get_machines():
                 task_id = self.post_task(files, payload, each)


### PR DESCRIPTION
Converting the string to lowercase is only necessary for seeing if 'ALL' is selected. Doing so beforehand breaks submissions to individual machine names with capital letters (ex. Cuckoo-Win7 )
