### PR TITLE
Improve Method/Reference input for PCAP and Email scripts

### DIFF
--- a/crits_scripts/scripts/add_email.py
+++ b/crits_scripts/scripts/add_email.py
@@ -21,8 +21,10 @@ class CRITsScript(CRITsBaseScript):
                 default=False, help="YAML file to import")
         oparse.add_option("-s","--source", action="store", dest="source",
                 type="string", help="source")
+        oparse.add_option("-m","--method", action="store", dest="method",
+                type="string", default="", help="source method")
         oparse.add_option("-r","--reference", action="store", dest="reference",
-                type="string", default="", help="source")
+                type="string", default="", help="source reference")
         (opts, args) = oparse.parse_args(argv)
 
         if not opts.eml and not opts.json and not opts.yaml:
@@ -36,12 +38,18 @@ class CRITsScript(CRITsBaseScript):
         if opts.eml:
             filename = opts.eml
             handler = handle_eml
+            method = "Command Line EML Upload"
         elif opts.json:
             filename = opts.json
             handler = handle_json
+            method = "Command Line JSON Upload"
         elif opts.yaml:
             filename = opts.yaml
             handler = handle_yaml
+            method = "Command Line YAML Upload"
+
+        if opts.method:
+            method = method + " - " + opts.method
 
         try:
             fh = open(filename, 'rb')
@@ -55,7 +63,7 @@ class CRITsScript(CRITsBaseScript):
             return
 
         obj = handler(data, opts.source, opts.reference, self.username,
-                      "Command line")
+                      method)
         if obj['status']:
             try:
                 obj['object'].save()

--- a/crits_scripts/scripts/add_pcap_file.py
+++ b/crits_scripts/scripts/add_pcap_file.py
@@ -17,6 +17,10 @@ class CRITsScript(CRITsBaseScript):
                 type="string", help="scanned FILENAME")
         parser.add_option("-s", "--source", action="store",
                 dest="source", type="string", help="source")
+        parser.add_option("-m", "--method", action="store",
+                dest="method", type="string", help="source method")
+        parser.add_option("-r", "--reference", action="store",
+                dest="reference", type="string", help="source reference")
         parser.add_option("-p", "--parent", action="store", dest="parent",
                 type="string", default="", help="parent md5")
         parser.add_option("-P", "--parent-type", action="store", dest="parent_type",
@@ -38,7 +42,8 @@ class CRITsScript(CRITsBaseScript):
         parent = opts.parent
         parent_type = opts.parent_type
         user = opts.user
-        method = "Command line add_pcap_file.py"
+        method = opts.method or "Command line add_pcap_file.py"
+        reference = opts.reference
 
         f = open(filename, 'rb')
         data = f.read()
@@ -47,7 +52,7 @@ class CRITsScript(CRITsBaseScript):
 
         status = handle_pcap_file(fname, data, source, user, description,
                                   parent_md5=parent, parent_type=parent_type,
-                                  method=method)
+                                  method=method, reference=reference)
 
         if status['success']:
             md5 = hashlib.md5(data).hexdigest()


### PR DESCRIPTION
With the intent of being thorough and consistent, I updated these two scripts to fit with the changes in CRITs PR 249 (Improve Source field consistency in TLO upload forms)
