### PR TITLE
Set Chopshop and Metacap To Not Run in Python Pools

### DIFF
--- a/chopshop_service/__init__.py
+++ b/chopshop_service/__init__.py
@@ -26,6 +26,7 @@ class ChopShopService(Service):
     template = "chopshop_analysis.html"
     supported_types = ['PCAP']
     description = "Extract HTTP and DNS data from a PCAP."
+    compatability_mode = True
 
     @staticmethod
     def parse_config(config):

--- a/metacap_service/__init__.py
+++ b/metacap_service/__init__.py
@@ -29,6 +29,7 @@ class MetaCapService(Service):
     template = "metacap_service_template.html"
     description = "Generate layer 3 and 4 metadata from a PCAP."
     supported_types = ['PCAP']
+    compatability_mode = True
 
     @staticmethod
     def parse_config(config):


### PR DESCRIPTION
Setting chopshop and metacap to compatibility mode, this will make them run in a Thread or Process if SERVICE_MODEL is thread_pool or process_pool respectively.
