### PR TITLE
Fix add_file and test_handle_file scripts.

### DIFF
--- a/crits_scripts/scripts/add_file.py
+++ b/crits_scripts/scripts/add_file.py
@@ -15,8 +15,10 @@ class CRITsScript(CRITsBaseScript):
                 type="string", help="scanned FILENAME")
         parser.add_option("-s", "--source", action="store",
                 dest="source", type="string", help="source")
-        parser.add_option("-p", "--parent", action="store", dest="parent",
-                type="string", help="parent md5")
+        parser.add_option("-p", "--parent", action="store", dest="parent_md5",
+                type="string", help="parent MD5")
+        parser.add_option("-i", "--parent-id", action="store", dest="parent_id",
+                type="string", help="parent ID")
         parser.add_option("-P", "--parent-type", action="store", dest="parent_type",
                 type="string", default="Sample", help="parent type (Sample, PCAP, ...)")
         parser.add_option("-t", "--trojan", action="store", dest="trojan",
@@ -32,7 +34,10 @@ class CRITsScript(CRITsBaseScript):
             source = opts.source
         else:
             print "[-] Source required, none provided"
-            exit(1)
+            return
+        if opts.parent_md5 and opts.parent_id:
+            print "[-] Specify one of -p or -i!"
+            return
         try:
             fin = open(opts.filename, 'rb')
             data = fin.read()
@@ -43,10 +48,14 @@ class CRITsScript(CRITsBaseScript):
         except:
             print "[-] Cannot open %s for reading!" % opts.filename
             return
-        if opts.parent:
-            parent = opts.parent
+        if opts.parent_md5:
+            parent_md5 = opts.parent_md5
         else:
-            parent = None
+            parent_md5 = None
+        if opts.parent_id:
+            parent_id = opts.parent_id
+        else:
+            parent_id = None
         parent_type = opts.parent_type
         if opts.trojan:
             trojan = opts.trojan
@@ -58,15 +67,15 @@ class CRITsScript(CRITsBaseScript):
             filename,
             data,
             source,
-            opts.reference,
+            reference=opts.reference,
             backdoor=trojan,
             user=self.username,
-            parent_md5=parent,
-            parent_type=parent_type,
+            related_md5=parent_md5,
+            related_id=parent_id,
+            related_type=parent_type,
             method="Command line add_file.py",
             bucket_list=opts.bucket_list)
         if sourcemd5 != sample:
             print "[-] Source MD5: %s is not the same as the returned MD5: %s" % (sourcemd5, sample)
-            exit(1)
         else:
             print "[+] Added %s (MD5: %s)" % (filename, sample)

--- a/crits_scripts/scripts/test_handle_file.py
+++ b/crits_scripts/scripts/test_handle_file.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from crits.services.analysis_result import AnalysisResult
 from crits.core.mongo_tools import mongo_connector, put_file
 from crits.samples.handlers import handle_file
 from crits.samples.sample import Sample
@@ -7,9 +8,12 @@ from crits.core.basescript import CRITsBaseScript
 
 class TestFile(object):
     """
-    def handle_file(filename, data, source, reference=None, parent=None,
-                    backdoor=None, user='', method='Generic', md5_digest=None,
-                    bucket_list=None, parent_type='Sample'):
+    def handle_file(filename, data, source, method='Generic', reference=None, related_md5=None,
+                    related_id=None, related_type='Sample', backdoor=None, user='',
+                    campaign=None, confidence='low', md5_digest=None, bucket_list=None,
+                    ticket=None, relationship=None, inherited_source=None, is_validate_only=False,
+                    is_return_only_md5=True, cache={}):
+
     """
     test_filename = "test_file.txt"
     test_data = "the quick brown fox jumps the lazy dog"
@@ -70,8 +74,9 @@ class TestFile(object):
     def _check_triage(self):
         sample = Sample.objects(md5=self.test_md5).first()
         results = False
-        if sample and len(sample.analysis) > 0 and sample.filedata:
-            results = True
+        if sample and sample.filedata:
+            if len(AnalysisResult.objects(object_id=str(sample.id))) > 0:
+                results = True
         print "[?] sample analysis executed == %s" % results
         return results
 


### PR DESCRIPTION
For add_file:
- add_file broke when the arguments were changed to related_ from parent_.
- This commit also adds the ability to add files related by ID. You can not
  specify both a related MD5 and a related ID though.
- Fix a couple of cases where the script was calling sys.exit instead of
  return.
- Finally, fix the actual call to handle_file. It was using parent_ instead
  of the related_ family of arguments. It was also missing passing reference
  by keyword.

For test_handle_file:
- Fix the docstring that contains the definition for handle_file.
- Use AnalysisResult now.
