### PR TITLE
Enhanced VT service to pull selected items available with a private key

### DIFF
--- a/virustotal_service/DEPENDENCIES
+++ b/virustotal_service/DEPENDENCIES
@@ -1,2 +1,2 @@
-The Virustotal service has no dependencies outside of those that are required
-for CRITs to run.
+The Virustotal service requires the following python modules:
+	- Requests

--- a/virustotal_service/README
+++ b/virustotal_service/README
@@ -1,4 +1,5 @@
-Check the VirusTotal database to see if it contains this sample, domain or IP.
+This service checks the VirusTotal database to see if it contains this sample, domain or IP. It will then collect relevant data using either a public or 
+private key.
 
 This does not submit the file to VirusTotal, but only performs a lookup of the
 sample's MD5.

--- a/virustotal_service/__init__.py
+++ b/virustotal_service/__init__.py
@@ -2,11 +2,19 @@ import logging
 import simplejson
 import urllib
 import urllib2
+import urlparse
+import requests
+
+from hashlib import md5
 
 from django.conf import settings
 from django.template.loader import render_to_string
 
 from crits.services.core import Service, ServiceConfigError
+from crits.pcaps.handlers import handle_pcap_file
+from crits.domains.handlers import get_domain, upsert_domain
+from crits.domains.domain import Domain
+from crits.core.user_tools import get_user_organization
 
 from . import forms
 
@@ -22,10 +30,14 @@ class VirusTotalService(Service):
     lookup of the sample's MD5.
 
     Requires an API key available from virustotal.com
+
+    TODO:
+        - Add IP addresses to domains....maybe. 
+        - Perform a check to see if the API key is really private
     """
 
     name = "virustotal_lookup"
-    version = '3.0.0'
+    version = '3.1.0'
     supported_types = ['Sample', 'Domain', 'IP']
     required_fields = []
     description = "Look up a Sample, Domain or IP in VirusTotal"
@@ -74,7 +86,51 @@ class VirusTotalService(Service):
 
         return display_config
 
+    def get_pcap(self, md5):
+        """
+        Retreives a PCAP files from VT using the Private API.
+
+        Args: 
+            md5 (String): MD5 of the sample we would like to pull the pcap from.
+
+        TODO: 
+            Add optional switch in the get request to store the pcap as a temp file
+                before adding it to Crits. Switch is stream=True and Crits provides
+                a handler for temp files. 
+            Make Error message uniform like the rest
+        """
+        network_url = self.config.get('vt_network_url', '')
+        params = {'apikey': self.config.get('vt_api_key', ''),
+                  'hash': md5
+        }
+
+        try:
+            response = requests.get(network_url, params=params)
+        except Exception as e:
+            logger.error("Virustotal: network connection error for PCAP (%s)" % e)
+            self._error("Network connection error checking virustotal for PCAP (%s)" % e)
+            return
+
+        if response.headers['content-type'] == 'application/cap':
+            self._info("Gathered PCAP file for %s" % md5)
+            return response.content
+        elif response.headers['content-type'] == 'application/json':
+            self._warning("Could not fetch PCAP for hash %s" % md5)
+            return None
+        else:
+            self._warning("Could not fetch PCAP for unknown reasons")
+            return None
+
     def run(self, obj, config):
+        # We assign config and obj to self because it is referenced often outside this script
+        # This is model after the guys who wrote the cuckoo script and all credit goes to them
+        # on this cool trick
+        self.config = config
+        self.obj = obj
+
+        # Pull configuration and check to see if a key is presented
+        private_key = config.get('vt_api_key_private', False)
+        pull_pcap = config.get('vt_api_pcap', False)
         key = config.get('vt_api_key', '')
         sample_url = config.get('vt_query_url', '')
         domain_url = config.get('vt_domain_url', '')
@@ -83,8 +139,12 @@ class VirusTotalService(Service):
             self._error("No valid VT key found")
             return
 
+        # Process parameters for a GET request for Sample, Domain, or IP adress
         if obj._meta['crits_type'] == 'Sample':
-            parameters = {"resource": obj.md5, "apikey": key}
+            if private_key:
+                parameters = {"resource": obj.md5, "apikey": key, 'allinfo': 1}
+            else:
+                parameters = {"resource": obj.md5, "apikey": key}
             vt_data = urllib.urlencode(parameters)
             req = urllib2.Request(sample_url, vt_data)
         elif obj._meta['crits_type'] == 'Domain':
@@ -96,6 +156,7 @@ class VirusTotalService(Service):
             vt_data = urllib.urlencode(parameters)
             req = urllib2.Request("%s?%s" % (ip_url, vt_data))
 
+        # Execute GET request
         if settings.HTTP_PROXY:
             proxy = urllib2.ProxyHandler({'https': settings.HTTP_PROXY})
             opener = urllib2.build_opener(proxy)
@@ -109,90 +170,617 @@ class VirusTotalService(Service):
             self._error("Network connection error checking virustotal (%s)" % e)
             return
 
+        # Check to see if a VT provided valid results. If not throw error and exit
         if response_dict.get('response_code', 0) != 1:
+            self._error("Exiting because Virustotal provided a negative response code.")
             return
 
+        # Process Results for Sample
         if obj._meta['crits_type'] == 'Sample':
-            self._debug(response_dict.get('verbose_msg', 'No message from VT'))
-            stats = {
-                'scan_date':        response_dict.get('scan_date', ''),
-                'positives':        response_dict.get('positives', 0),
-                'total':            response_dict.get('total', 0),
-            }
-            result_string = "%d / %d" % (response_dict.get('positives', 0), response_dict.get('total', 0))
-            self._add_result('stats', result_string, stats)
-            self._add_result('permalink', response_dict.get("permalink", "No link"))
-            scans = response_dict.get('scans', [])
-            for scan in scans:
-                if scans[scan]["result"]:
-                    result = scans[scan]["result"]
-                else:
-                    result = ''
-                detection = {
-                    "engine":       scan,
-                    "date":         scans[scan].get('update', ''),
-                    "detected":     scans[scan].get('detected', ''),
-                    "version":      scans[scan].get('version', ''),
-                }
-                self._add_result('av_result', result, detection)
+            # Process Public Key data and store scandate for later use
+            response = self._process_public_sample(response_dict)
+            if not response['success']:
+                self._debug(response['message'])
+            scandate = response.get('scandate', None)
+
+            # If selected, process private key data
+            if private_key:
+                ###
+                # TODO: catch to see if the key is really private
+                ###
+
+                # Process private metadata
+                response = self._process_private_sample_metadata(response_dict)
+                if not response['success']:
+                    self._debug(response['message'])
+
+                # Process private VirusTotal metadata
+                response = self._process_private_sample_vtmetadata(response_dict)
+                if not response['success']:
+                    self._debug(response['message'])
+
+                # Process private VirusTotal behaviour information
+                response = self._process_private_sample_behaviour(response_dict, scandate)
+                if not response['success']:
+                    self._debug(response['message'])
+
+                # Pull pcap file, add to DB, and create relationship
+                if pull_pcap:
+                    pcap = self.get_pcap(obj.md5)
+                    if pcap:
+                        self._process_pcap(pcap, scandate)
+
+        # Process results for Domain
         elif obj._meta['crits_type'] == 'Domain':
-            for detected_url in response_dict.get('detected_urls', []):
+            # Process public VirusTotal domain information
+            response = self._process_public_domain(response_dict)
+            if not response['success']:
+                self._debug(response['message'])
+
+        # Process results for IP
+        elif obj._meta['crits_type'] == 'IP':
+            # Process public VirusTotal ip information
+            response = self._process_public_ip(response_dict)
+            if not response['success']:
+                self._debug(response['message'])
+
+    def _process_public_sample(self, report):
+        """
+        Process public key sample data from VirusTotal.
+
+        Args:
+            report (dict): json report information
+
+        Return: dict with keys:
+            'success' (boolean),
+            'message' (str),
+            'scandate' (str), if available 
+        """
+        status = {
+            'success':  False,
+            'message':  []
+        }
+
+        # Checks to see if VT verbose_msg is provided. If not exit and return message
+        vtmsg = report.get('verbose_msg', False)
+        if not vtmsg:
+            status['message'].append("No verbose message provided by VT.")
+
+        # Add VT header information. Composed of information overview and permalink
+        stats = {
+            'scan_date':        report.get('scan_date', ''),
+            'positives':        report.get('positives', 0),
+            'total':            report.get('total', 0),
+        }
+        result_string = "%d / %d" % (report.get('positives', 0), report.get('total', 0))
+        status['scandate'] = stats['scan_date']
+        self._add_result('stats', result_string, stats)
+        self._add_result('permalink', report.get("permalink", "No link"))
+
+        # Add VT scan data
+        scans = report.get('scans', [])
+        for scan in scans:
+            if scans[scan]["result"]:
+                result = scans[scan]["result"]
+            else:
+                result = ''
+            detection = {
+                "engine":       scan,
+                "date":         scans[scan].get('update', ''),
+                "detected":     scans[scan].get('detected', ''),
+                "version":      scans[scan].get('version', ''),
+            }
+            self._add_result('av_result', result, detection)
+        else:
+            status['message'].append("Scan data not included in VT response.")
+
+        # Updating status information and returning 
+        if not status['message']:
+            status['success'] =  True
+            status['message'] = "Processed Public Report Information."
+        else:
+            status['message'] = "\n".join(status['message'])
+
+        return status
+
+    def _process_private_sample_metadata(self, report):
+        """
+        Process private sample report information focused on file meta data 
+        from VirusTotal. This includes the section:
+            - Developer Data
+            - PE Language
+            - Signature Check
+        Args:
+            report (dict): unprocessed main json report information from VT. 
+
+        Return: dict with keys:
+            'success' (boolean),
+            'message' (str),
+        """
+        status = {
+            'success':  False,
+            'message':  []
+        }
+        additional_info_dict = report.get('additional_info', {})
+        exiftool_dict = additional_info_dict.get('exiftool', {})
+        sigcheck_dict = additional_info_dict.get('sigcheck', {})
+
+        # Developer Metadata
+        if exiftool_dict:
+            developerdata = {
+                'Product_Name': exiftool_dict.get('ProductName', ''),
+                'Product_Version': exiftool_dict.get('ProductVersionNumber', ''),
+                'File_Version': exiftool_dict.get('FileVersionNumber', ''),
+                'File_Description': exiftool_dict.get('FileDescription', ''),
+                'InternalName': exiftool_dict.get('InternalName', ''),
+            }
+            self._add_result('Developer_Metadata', exiftool_dict.get('CompanyName', ''), developerdata)
+        else:
+            status['message'].append("Exiftool data not included in VT response.")
+
+        # Signature Information
+        if sigcheck_dict:
+            sigcheck = {
+                'Copyright': sigcheck_dict.get('copyright', ''),
+                'Description': sigcheck_dict.get('description', ''),
+                'File_Version': sigcheck_dict.get('file version', ''),
+                'Internal_Name': sigcheck_dict.get('internal name', ''),
+                'Original_Name': sigcheck_dict.get('original name', ''),
+                'Product': sigcheck_dict.get('product', ''),
+                'Link_Data': sigcheck_dict.get('link date', ''),
+                'Publisher': sigcheck_dict.get('publisher', ''),
+                'Signers': sigcheck_dict.get('signers', ''),
+                'Signing Date': sigcheck_dict.get('signing date', '')
+            }
+            self._add_result('Signature_Information', sigcheck_dict.get('publisher', ''), sigcheck)
+        else:
+            status['message'].append("Signature data not included in VT response.")
+
+        # PE Language Informaton
+        pe_lang = additional_info_dict.get('pe-resource-langs', {})
+        if pe_lang:
+            self._add_result('Language_Information', exiftool_dict.get('LanguageCode', ''), pe_lang)
+        else:
+            status['message'].append("PE Language data not included in VT response.")
+
+        # Updating status information and returning 
+        if not status['message']:
+            status['success'] =  True
+            status['message'] = "Processed private sample metadata."
+        else:
+            status['message'] = "\n".join(status['message'])
+
+        return status
+
+    def _process_private_sample_vtmetadata(self, report):
+        """
+        Process private sample report information focused on virustotal's
+        metadata. This includes the section:
+            - VirusTotal Metadata (times seen)
+            - VirusTotal Reputation
+        Args:
+            report (dict): unprocessed main json report information from VT. 
+
+        Return: dict with keys:
+            'success' (boolean),
+            'message' (str),
+        """
+        status = {
+            'success':  False,
+            'message':  []
+        }
+
+        additional_info_dict = report.get('additional_info', {})
+
+        # VirusTotal Metadata
+        if additional_info_dict:
+            vt_metadata = {
+                'First_Seen': report.get('first_seen', ''),
+                'Last_Seen': report.get('last_seen', ''),
+                'Times_Submitted': report.get('times_submitted', ''),
+                'Unique_Sources': report.get('unique_sources', '')
+            }
+            self._add_result('Virus_Total_Metadata', report.get('scan_id', ''), vt_metadata)
+            for item in report.get('submission_names', []):
+                self._add_result('Virus_Total_Metadata', item, {'Submission_Name': 'Submission Name(s)'})
+
+            # VirusTotal Reputation
+            vt_reputation = {
+                'Community_Reputation': report.get('community_reputation', 0),
+                'Harmless_Votes':       report.get('harmless_votes', 0),
+                'Malicious_Votes':      report.get('malicious_votes', 0)
+            }
+            vt_reputation_string =  "%d / %d" % (report.get('malicious_votes', 0), report.get('harmless_votes', 0))
+            self._add_result('Virus_Total_Reputation', vt_reputation_string, vt_reputation)
+        else:
+            status['message'].append("Additional information not included in VT response.")
+
+
+        # Updating status information and returning 
+        if not status['message']:
+            status['success'] =  True
+            status['message'] = "Processed private sample vtmetadata."
+        else:
+            status['message'] = "\n".join(status['message'])
+
+        return status
+
+    def _process_private_sample_behaviour(self, report, scandate):
+        """
+        Process private sample report information focused on virustotal's
+        behaviour information. This includes the section:
+            - VirusTotal Metadata (times seen)
+            - VirusTotal Reputation
+        Args:
+            report (dict): unprocessed main json report information from VT. 
+
+        Return: dict with keys:
+            'success' (boolean),
+            'message' (str),
+        """
+        status = {
+            'success':  False,
+            'message':  []
+        }
+        additional_info_dict = report.get('additional_info', {})
+        behaviour_dict = additional_info_dict.get('behaviour-v1', {})
+
+        # VirusTotal Network Behavioral Data
+        if behaviour_dict:
+            behaviour_network_dict = behaviour_dict.get('network', {})
+
+            if behaviour_network_dict:
+                # Grab DNS data if available 
+                behaviour_network_dns = behaviour_network_dict.get('dns', [])
+                if behaviour_network_dns:
+                    for item in behaviour_network_dns:
+                        self._process_domain(item.get('hostname', ''), item.get('ip', ''), scandate)
+                else:
+                    status['message'].append("DNS behaviour information not included in VT response.")
+
+                # Grab HTTP data if available 
+                behaviour_network_http = behaviour_network_dict.get('http', [])
+                if behaviour_network_http:
+                    for item in behaviour_network_http:
+                        item_dict = {
+                            'Method':       item.get('method', ''),
+                            'User-agent':   item.get('user-agent', '')
+                        }
+                        self._add_result('Virus_Total_Behaviour_HTTP', item.get('url', ''), item_dict)
+                else:
+                    status['message'].append("HTTP behaviour information not included in VT response.")
+
+                # Grab TCP data if available 
+                behaviour_network_tcp = behaviour_network_dict.get('tcp', [])
+                if behaviour_network_tcp:
+                    for item in behaviour_network_tcp:
+                        self._add_result('Virus_Total_Behaviour_TCP', item)
+                else:
+                    status['message'].append("TCP behaviour information not included in VT response.")
+
+                # Grab UDP data if available 
+                behaviour_network_udp = behaviour_network_dict.get('udp', [])
+                if behaviour_network_udp:
+                    for item in behaviour_network_udp:
+                        self._add_result('Virus_Total_Behaviour_UDP', item)
+                else:
+                    status['message'].append("UDP behaviour information not included in VT response.")
+
+            # VirusTotal Extra Flags
+            behaviour_extra = behaviour_dict.get('extra', [])
+            if behaviour_extra:
+                for item in behaviour_extra:
+                    self._add_result('Virus_Total_Behaviour_Flag', item, {'VT_Flag': 'VT_Flag'})
+            else:
+                status['message'].append("Behaviour flag information not included in VT response.")
+
+            # VirusTotal Hooking Detection
+            behaviour_hooking = behaviour_dict.get('hooking', [])
+            if behaviour_hooking:
+                for item in behaviour_hooking:
+                    item_dict = {
+                        'method':   item.get('method', ''),
+                        'success':  item.get('success', '')
+                    }
+                    self._add_result('Virus_Total_Hooking_Detected', item.get('type', ''), item_dict)
+            else:
+                status['message'].append("Hooking behaviour information not included in VT response.")
+
+        else:
+            status['message'].append("Behaviour information not included in VT response.")
+
+        # Updating status information and returning 
+        if not status['message']:
+            status['success'] =  True
+            status['message'] = "Processed private sample behaviour data."
+        else:
+            status['message'] = "\n".join(status['message'])
+
+        return status
+
+    def _process_public_domain(self, report):
+        """
+        Process public key domain data from VirusTotal. This is a mess on VT's side. Standards....
+
+        Args:
+            report (dict): json report information
+
+        Return: dict with keys:
+            'success' (boolean),
+            'message' (str),
+        """
+        status = {
+            'success':  False,
+            'message':  []
+        }
+
+        detected_urls = report.get('detected_urls', [])
+        if detected_urls:
+            for detected_url in detected_urls:
                 stats = {
                           'scan_date': detected_url.get('scan_date', ''),
                           'total': detected_url.get('total', 0),
                           'positives': detected_url.get('positives', 0),
                         }
                 self._add_result('URLs', detected_url.get('url', ''), stats)
+        else:
+            status['message'].append("URL information not included in VT response.")
 
-            for resolution in response_dict.get('resolutions', []):
+        resolutions = report.get('resolutions', [])
+        if resolutions:
+            for resolution in resolutions:
                 stats = { 'last_resolved': resolution.get('last_resolved', '') }
                 self._add_result('A Records', resolution.get('ip_address', ''), stats)
+        else:
+            status['message'].append("Resolution information not included in VT response.")
 
-            for category in response_dict.get('categories', []):
+        categories = report.get('categories', [])
+        if categories:
+            for category in categories:
                 self._add_result('Categories', category, {})
-        elif obj._meta['crits_type'] == 'IP':
-            for samp in response_dict.get('detected_communicating_samples', []):
-                stats = {
-                          'date': samp.get('date', ''),
-                          'total': samp.get('total', 0),
-                          'positives': samp.get('positives', 0)
-                        }
-                self._add_result('Detected Communicating Samples', samp.get('sha256', ''), stats)
+        else:
+            status['message'].append("Category information not included in VT response.")
 
-            for samp in response_dict.get('undetected_communicating_samples', []):
+        communicating_samples = report.get('detected_communicating_samples', [])
+        if communicating_samples:
+            for sample in communicating_samples:
                 stats = {
-                          'date': samp.get('date', ''),
-                          'total': samp.get('total', 0),
-                          'positives': samp.get('positives', 0)
+                          'date': sample.get('date', ''),
+                          'total': sample.get('total', 0),
+                          'positives': sample.get('positives', 0),
                         }
-                self._add_result('Undetected Communicating Samples', samp.get('sha256', ''), stats)
+                self._add_result('Detected Communicating Samples', sample.get('sha256', 0), stats)
+        else:
+            status['message'].append("Detected communicating sample information not included in VT response.")
 
-            for samp in response_dict.get('detected_downloaded_samples', []):
+        # This is added in the IP data from the original VT service. However I have not see this used. I am adding it
+        # just incase.
+        undetected_communicating_samples = report.get('undetected_communicating_samples', [])
+        if undetected_communicating_samples:
+            for sample in undetected_communicating_samples:
                 stats = {
-                          'date': samp.get('date', ''),
-                          'total': samp.get('total', 0),
-                          'positives': samp.get('positives', 0)
+                          'date': sample.get('date', ''),
+                          'total': sample.get('total', 0),
+                          'positives': sample.get('positives', 0),
                         }
-                self._add_result('Detected Downloaded Samples', samp.get('sha256', ''), stats)
+                self._add_result('Undetected Communicating Samples', sample.get('sha256', 0), stats)
+        else:
+            status['message'].append("Undetected communicating sample information not included in VT response.")
 
-            for samp in response_dict.get('undetected_downloaded_samples', []):
+        downloaded_samples = report.get('detected_downloaded_samples', [])
+        if downloaded_samples:
+            for sample in downloaded_samples:
                 stats = {
-                          'date': samp.get('date', ''),
-                          'total': samp.get('total', 0),
-                          'positives': samp.get('positives', 0)
+                          'date': sample.get('date', ''),
+                          'total': sample.get('total', 0),
+                          'positives': sample.get('positives', 0),
                         }
-                self._add_result('Undetected Downloaded Samples', samp.get('sha256', ''), stats)
+                self._add_result('Detected Downloaded Samples', sample.get('sha256', 0), stats)
+        else:
+            status['message'].append("Downloaded sample information not included in VT response.")
 
-            for url in response_dict.get('detected_urls', []):
+        undetected_downloaded_samples = report.get('undetected_downloaded_samples', [])
+        if undetected_downloaded_samples:
+            for sample in undetected_downloaded_samples:
+                stats = {
+                          'date': sample.get('date', ''),
+                          'total': sample.get('total', 0),
+                          'positives': sample.get('positives', 0),
+                        }
+                self._add_result('Undetected Downloaded Samples', sample.get('sha256', 0), stats)
+        else:
+            status['message'].append("Undetected domain sample information not included in VT response.")
+
+        # Updating status information and returning 
+        if not status['message']:
+            status['success'] =  True
+            status['message'] = "Processed public domain information."
+        else:
+            status['message'] = "\n".join(status['message'])
+
+        return status
+
+    def _process_public_ip(self, report):
+        """
+        Process public key ip data from VirusTotal. 
+
+        Args:
+            report (dict): json report information
+
+        Return: dict with keys:
+            'success' (boolean),
+            'message' (str),
+        """
+        status = {
+            'success':  False,
+            'message':  []
+        }
+
+        detected_urls = report.get('detected_urls', [])
+        if detected_urls:
+            for url in detected_urls:
                 stats = {
                           'scan_date': url.get('scan_date', ''),
                           'total': url.get('total', 0),
                           'positives': url.get('positives', 0)
                         }
                 self._add_result('Detected URLs', url.get('url', ''), stats)
+        else:
+            status['message'].append("Detected URL information not included in VT response.")       
 
-            for resolution in response_dict.get('resolutions', []):
+        resolutions = report.get('resolutions', [])
+        if resolutions:
+            for resolution in resolutions:
                 stats = {
                           'last_resolved': resolution.get('last_resolved', ''),
                         }
                 self._add_result('Resolutions', resolution.get('hostname', ''), stats)
+        else:
+            tatus['message'].append("Resolution information not included in VT response.")
+
+        detected_communicating_samples = report.get('detected_communicating_samples', [])
+        if detected_communicating_samples:
+            for samp in detected_communicating_samples:
+                stats = {
+                          'date': samp.get('date', ''),
+                          'total': samp.get('total', 0),
+                          'positives': samp.get('positives', 0)
+                        }
+                self._add_result('Detected Communicating Samples', samp.get('sha256', ''), stats)
+        else:
+            status['message'].append("Detected communicating sample information not included in VT response.")
+
+        undetected_communicating_samples = report.get('undetected_communicating_samples', [])
+        if undetected_communicating_samples:
+            for samp in undetected_communicating_samples:
+                stats = {
+                          'date': samp.get('date', ''),
+                          'total': samp.get('total', 0),
+                          'positives': samp.get('positives', 0)
+                        }
+                self._add_result('Undetected Communicating Samples', samp.get('sha256', ''), stats)
+        else:
+            status['message'].append("Undetected communicating sample information not included in VT response.")
+
+        detected_downloaded_samples = report.get('detected_downloaded_samples', [])
+        if detected_downloaded_samples:
+            for samp in detected_downloaded_samples:
+                stats = {
+                          'date': samp.get('date', ''),
+                          'total': samp.get('total', 0),
+                          'positives': samp.get('positives', 0)
+                        }
+                self._add_result('Detected Downloaded Samples', samp.get('sha256', ''), stats)
+        else:
+            status['message'].append("Detected downloaded sample information not included in VT response.")
+
+        undetected_downloaded_samples = report.get('undetected_downloaded_samples', [])
+        if undetected_downloaded_samples:
+            for samp in undetected_downloaded_samples:
+                stats = {
+                          'date': samp.get('date', ''),
+                          'total': samp.get('total', 0),
+                          'positives': samp.get('positives', 0)
+                        }
+                self._add_result('Undetected Downloaded Samples', samp.get('sha256', ''), stats)
+        else:
+            status['message'].append("Undetected downloaded sample information not included in VT response.")       
+
+        # Updating status information and returning 
+        if not status['message']:
+            status['success'] =  True
+            status['message'] = "Processed public ip information."
+        else:
+            status['message'] = "\n".join(status['message'])
+
+        return status
+
+    def _process_pcap(self, pcap, scandate):
+        """
+        Add Pcap file to Crits. 
+
+        Args:
+            pcap (binary): pcap data
+            scandate (str): scan date from when pcap was collected
+
+        TODO:
+            Add an error check
+        """
+        self._info("Adding PCAP and creating relationship to %s" % (str(self.obj.id)))
+        self._notify()
+        org = get_user_organization(self.current_task.username)
+        h = md5(pcap).hexdigest()
+        result = handle_pcap_file("%s.pcap" % h,                            # File Name
+                                  pcap,                                     # Pcap data
+                                  org,                                      # Data Source
+                                  user=self.current_task.username,          # User adding the PCAP
+                                  description='Created %s' % (scandate),    # Description 
+                                  related_id=str(self.obj.id),              # Top level ID of related object
+                                  related_type="Sample",                    # Top level type of the related object
+                                  method=self.name,                         # Method for aquiring the PCAP
+                                  reference=None,                           # Reference to the source of this PCAP
+                                  relationship='Related_To')                # Relationship between parent and the PCAP         
+        self._add_result("pcap_added", h, {'md5': h})
+
+    def _process_domain(self, domain, ip, scandate):
+        """
+        Add domain to Crits. 
+
+        Args:
+            domain (str): pcap data
+            scandate (str): scan date from when domain is believed to be collected. 
+
+        TODO:
+            handle IP
+        """
+
+        if domain == 'none':
+            self._debug("Domain is blank: %s." % (domain))
+        else:
+            self._info("Adding domain %s and creating relationship to %s" % (str(domain), str(self.obj.id)))
+            self._notify()
+            org = get_user_organization(self.current_task.username)
+
+            url_contains_ip = False
+            #domain_host = urlparse.urlparse(domain).hostname
+            (sdomain, fqdn) = get_domain(domain)
+            if sdomain == "no_tld_found_error":
+                try:
+                    validate_ipv46_address(domain_or_ip)
+                    url_contains_ip = True
+                except DjangoValidationError:
+                    pass
+            if not url_contains_ip:
+                result = None
+                result = upsert_domain(sdomain,                                  # Root domain
+                                       fqdn,                                     # domain
+                                       org,                                      # Data Source
+                                       username=self.current_task.username,          # User adding the Domain
+                                       campaign=None,                            # Link to campaign
+                                       confidence=None,
+                                       bucket_list=None,
+                                       ticket=None)
+
+                # If domain was added, create relationship.
+                if not result['success']:
+                    self._debug("Cannot add domain %s. reason: %s" % (str(domain), str(result['message'])))
+                else:
+                    # add relationshiop
+                    dmain = result['object']
+
+                    msg = dmain.add_relationship(rel_item=self.obj,         #the top-level object to relate to
+                                                 rel_type='Related_To',       
+                                                 rel_date=scandate,
+                                                 analyst=self.current_task.username,
+                                                 rel_confidence='unknown',
+                                                 rel_reason='Provided by VirusTotal. Date is from when vt analysis was performed',
+                                                 get_rels=False)
+                    
+                    if not msg['success']:
+                        self._debug("Cannot add relationship because %s" % (str(msg['message'])))
+                    
+                    dmain.save(username=self.current_task.username)
+                    self.obj.save(username=self.current_task.username)
+
+                    # Add domain to Crits
+                    self._add_result('Virus_Total_Behaviour_DNS', str(domain), {'IP_Address': str(ip)})

--- a/virustotal_service/forms.py
+++ b/virustotal_service/forms.py
@@ -3,6 +3,14 @@ from django import forms
 class VirusTotalConfigForm(forms.Form):
     error_css_class = 'error'
     required_css_class = 'required'
+    vt_api_key_private = forms.BooleanField(required=False,
+                                initial=False,
+                                label='Private key?',
+                                help_text="Is the key a private key?")
+    vt_api_pcap = forms.BooleanField(required=False,
+                                initial=False,
+                                label='Pull pcap?',
+                                help_text="If available, should we pull the pcap file?")
     vt_api_key = forms.CharField(required=True,
                                  label="API Key",
                                  widget=forms.TextInput(),
@@ -20,6 +28,11 @@ class VirusTotalConfigForm(forms.Form):
                                 label="IP URL",
                                 widget=forms.TextInput(),
                                 initial='https://www.virustotal.com/vtapi/v2/ip-address/report')
+    vt_network_url = forms.CharField(required=True,
+                                label="Network URL",
+                                widget=forms.TextInput(),
+                                initial='https://www.virustotal.com/vtapi/v2/file/network-traffic')
+
 
     def __init__(self, *args, **kwargs):
         super(VirusTotalConfigForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION

- Will pull private API information for samples.
- Provides an option to download pcap file.
    - Will add pcap to Crits and form a relationship.
    - Relationship dated from when VT analysis was performed.
- The service will add domains to crits if detected in samples.
- Cleaned up the Run() fuction:
    - Logical blocks now live in their own fuction.
    - Added a lot of code comments.
    - Not fully finished with this...but it is a start.
- Added error checks and output.
- Unified output for domains and IPs