### PR TITLE
[NEW] CHMInfo - a service to analyze ITSF (.chm) files

### DIFF
--- a/chminfo_service/DEPENDENCIES
+++ b/chminfo_service/DEPENDENCIES
@@ -1,0 +1,7 @@
+This plugin depends on the following packages:
+pychm (python-chm)
+libchm1
+HTTPParser
+
+Installation intructions:
+apt-get install python-chm libchm1

--- a/chminfo_service/DEPENDENCIES
+++ b/chminfo_service/DEPENDENCIES
@@ -1,7 +1,6 @@
 This plugin depends on the following packages:
-pychm (python-chm)
-libchm1
-HTTPParser
+- pychm
+- libchm1
 
 Installation intructions:
 apt-get install python-chm libchm1

--- a/chminfo_service/LICENSE
+++ b/chminfo_service/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) 2015, The MITRE Corporation. All rights reserved.
+
+Approved for Public Release; Distribution Unlimited 14-1511
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/chminfo_service/LICENSE
+++ b/chminfo_service/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015, wootski (https://github.com/wootski).
+Copyright (c) 2015, Karl Voss. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/chminfo_service/LICENSE
+++ b/chminfo_service/LICENSE
@@ -1,8 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015, The MITRE Corporation. All rights reserved.
-
-Approved for Public Release; Distribution Unlimited 14-1511
+Copyright (c) 2015, wootski (https://github.com/wootski).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/chminfo_service/README
+++ b/chminfo_service/README
@@ -1,0 +1,3 @@
+CHMInfo will parse a ITSF/Microsoft Compiled HTML help file and generate
+rich metadata about the document and provide basic malware detection
+capabilities.

--- a/chminfo_service/README
+++ b/chminfo_service/README
@@ -1,3 +1,3 @@
-CHMInfo will parse a ITSF/Microsoft Compiled HTML help file and generate
-rich metadata about the document and provide basic malware detection
-capabilities.
+CHMInfo will parse an ITSF/Microsoft Compiled HTML help file and
+generate rich metadata about the document and provide basic
+malware detection capabilities.

--- a/chminfo_service/__init__.py
+++ b/chminfo_service/__init__.py
@@ -59,11 +59,11 @@ class CHMInfoService(Service):
     @staticmethod
     def valid_for(obj):
         chm_magic = '\x49\x54\x53\x46\x03\x00\x00\x00\x60\x00\x00\x00'
-        if chmparse.filedata != None:
+        if obj.filedata != None:
             data = obj.filedata.read()
             # Need to reset the read pointer.
             obj.filedata.seek(0)
-            if data.startswith(office_magic):
+            if data.startswith(chm_magic):
                 return
         raise ServiceConfigError("Not a valid ITSF (CHM) file.")
 

--- a/chminfo_service/__init__.py
+++ b/chminfo_service/__init__.py
@@ -180,30 +180,16 @@ class CHMInfoService(Service):
         }
         return result
 
-    @classmethod
-    def load_chm(self, data):
-        """
-        Load CHM using CHM library
-        - Use tempfile as libchm will only accept a filename.
-        """
-        temp = tempfile.NamedTemporaryFile(delete=False)
-        temp.write(data)
-        temp.close()
-        try:
-            self.chmparse.LoadCHM(temp.name)
-        except Exception as e:
-            raise e
-        finally:
-            #Delete tempfile on disk
-            os.unlink(temp.name) 
-
     def run(self, obj, config):
         """
         Being plugin processing
         """
-        #Load sample
-        data = obj.filedata.read()
-        self.load_chm(data)
+        #Load data from file as libchm will only accept a filename
+        with self._write_to_file() as chm_file:
+            try:
+                self.chmparse.LoadCHM(chm_file)
+            except Exception as e:
+                raise e
 
         #Conduct analysis
         result = self.analyze()

--- a/chminfo_service/__init__.py
+++ b/chminfo_service/__init__.py
@@ -1,0 +1,236 @@
+import os
+import re
+import hashlib
+import tempfile
+import HTMLParser
+from chm import chm
+from contextlib import contextmanager
+
+from django.template.loader import render_to_string
+
+from crits.services.core import Service, ServiceConfigError
+from crits.samples.handlers import handle_file
+
+logger = logging.getLogger(__name__)
+
+class CHMInfoService(Service):
+    """
+    Microsoft Compiled HTML Help file information service
+    - Extract information from CHM
+    - Provde details about suspicious behaviour within a CHM
+    """
+    name = "chminfo"
+    version = '1.0.0'
+    supported_types = ['Sample']
+    description = "Generate information about Windows CHM files."
+    added_files = []
+
+    item_string = {r'x-oleobject':'CHM contains reference to OLE Object.',
+                    r'<script':'CHM contains JavaScript',
+                    r'.savetofile':'CHM contains a function to save data to file',
+                    r'document.write(':'CHM contains a function to save data to file.',
+                    r'adodb.stream':'CHM creates ADO steam object for file access',
+                    r'msxml2.xmlhttp':'CHM uses an XHLHTTP object to create a network connection',
+                    r'System.Net.WebClient':'CHM uses the PowerShell WebClient class to create a network connection',
+                    r'cmd.exe':'CHM references Windows command prompt',
+                    r'cscript':'CHM references console scripting host',
+                    r'wscript':'CHM references Windows scripting host',
+                    r'rundll32':'CHM contains suspicious reference to Windows file',
+                    r'powershell':'CHM references PowerShell',
+                    r'end if':'CHM contains if statement',
+                    }
+    item_regex = {r'<iframe\s.*src="([^\"]*)".*>':'CHM file creates an IFRAME',
+                    r'<object\s[^>]+codebase=\"([^\"]*)\"':'CHM contains object that references external code',
+                    r'<object\s[^>]+codebase=\'([^\"]*)\'':'CHM contains object that references external code',
+                    r'<object\s[^>]+data=\"([^\"]*)\"':'CHM contains object that references external code',
+                    r'<object\s[^>]+data=\'([^\"]*)\'':'CHM contains object that references external code',
+                    r'createobject\(([^\)]*)':'CHM attempts to create an object',
+                    r'.DownloadFile(([^\)]*)': 'CHM attempts to download a file',
+                    r'.exec\(([^\)]*)':'CHM attempts to execute a file',
+                    r'.shellexecute(([^\)]*)': 'CHM attempts to execute a file',
+                }
+
+    def __init__(self):
+        """
+        Initialize the CHMInfo service objects
+        """
+        self.chmparse = chm.CHMFile()
+        self.urls = []
+        self.items = []
+
+    @staticmethod
+    def valid_for(obj):
+        chm_magic = '\x49\x54\x53\x46\x03\x00\x00\x00\x60\x00\x00\x00'
+        if chmparse.filedata != None:
+            data = obj.filedata.read()
+            # Need to reset the read pointer.
+            obj.filedata.seek(0)
+            if data.startswith(office_magic):
+                return
+        raise ServiceConfigError("Not a valid ITSF (CHM) file.")
+
+    @classmethod
+    def find_items(self, data):
+        """
+        Find interesting CHM items using regex and strings
+        """
+        results = []
+        data = self.unescape(data).lower()
+        for match, desc in self.item_regex.items():
+            found = re.findall(match, data)
+            if found:
+                temp = desc + ' (' + found + ').'
+                results.append(temp)
+
+        for match, desc in self.item_string.items():
+            if match in data:
+                results.append(desc)
+        return results
+
+    @classmethod
+    def find_urls(self, data):
+        """
+        Extract URLs from document objects
+        """
+        results = []
+        url = re.compile(ur'''(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s
+            ()<>\'\"]+|\(([^\s()<>]+|(\([^\s()<>\'\"]+\)))*\))+(?:\(([^\s()<>\'\"]+|(\([^\s\(\)<>
+            \'\"]+\)))*\)|[^\s`!()\[\]{};:\'\"\.,<>?\xab\xbb\u201c\u201d\u2018\u2019]))''')
+        ip = re.compile(ur'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b')
+
+        data = self.unescape(data)
+        matches = re.findall(url,data)
+        for match in matches:
+            if not match in results:
+                results.append(match)
+
+        matches = re.findall(ip,data)
+        for match in matches:
+            if not match in results:
+                results.append(match)
+        return results
+
+    @staticmethod
+    def unescape(data):
+        """
+        Unescape HTML code
+        """
+        html_parser = HTMLParser.HTMLParser()
+        try:
+            data = data.decode('ascii','ignore')
+            data = html_parser.unescape(data)
+        except UnicodeDecodeError:
+            self._error('HTMLParser library encountered an error when decoding Unicode characters.')
+        data = data.replace('\',\'','')
+        data = data.replace('\",\"','')
+        return data
+
+    @classmethod
+    def analyse(self):
+        """
+        Extract metadata and analyze the CHM file
+        @return analysis results dictionary
+        """
+        obj_items = []
+        obj_items_details = {}
+        obj_items_summary = []
+        locale_desc = ''
+
+        locale_desc = chmparse.GetLCID()
+        if locale_desc:
+            locale_desc = ', '.join(local_desc)
+
+        #Create a list of items within the CHM
+        obj_items.append(chmparse.home)
+        obj_items.append(chmparse.index)
+        obj_items.append(chmparse.topics)
+        obj_items = [x for x in obj_items if x is not None]
+
+        #Analyse objects in CHM
+        for item in obj_items:
+            fetch = chmparse.ResolveObject(item)
+            if fetch[0] == 0:
+                #Read data for object
+                try:
+                    item_details = chmparse.RetrieveObject(fetch[1])
+                    if len(item_details) == 2:
+                        data = item_details[1]
+                        size = item_details[0]
+                        md5_digest = hashlib.md5(data).hexdigest()
+                        obj_items_details = {
+                            'name':         item,
+                            'size':         size,
+                            'md5':          md5_digest,
+                            'urls':         find_urls(data),
+                            'detection':    find_items(data),
+                        }
+                        obj_item_summary.append(obj_items_details)
+                    else:
+                        self._error('RetrieveObject() did not return data for "{}".'.format(item))
+                except Exception:
+                    self._error('Analysis of item "{}" failed.'.format(item))
+
+        result = {
+            'title':                chmparse.title,
+            'index':                chmparse.index,
+            'binary_index':         chmparse.binaryindex,
+            'topics':               chmparse.topics,
+            'home':                 chmparse.home,
+            'encoding':             chmparse.encoding,
+            'locale_id':            chmparse.lcid,
+            'locale_desc':          locale_desc,
+            'searchable':           str(chmparse.searchable),
+            'items':                ', '.join(obj_items),
+            'obj_items_summary':    obj_items_summary,
+        }
+        chmparse.CloseCHM()
+        return result
+
+    @contextmanager
+    def tempinput(data):
+        """
+        tempfile management
+        """
+        temp = tempfile.NamedTemporaryFile(delete=False)
+        temp.write(data)
+        temp.close()
+        yield temp.name
+        os.unlink(temp.name)
+
+    def run(self, obj, config):
+        """
+        Being plugin processing
+        """
+        data = obj.filedata.read()
+
+        with tempinput(data) as tempfilename:
+            self.chmparse.LoadCHM(tempfilename)
+
+        #Conduct analysis
+        result = self.analyze()
+
+        #Handle output of results
+        if result.get('obj_items_summary'):
+            obj_items_summary = result.pop('obj_items_summary')
+        
+        for key, value in result.items():
+            self._add_result('chm_overview', (key + ": " + value), {})
+
+        for object_item in obj_items_summary:
+            if object_item.get('urls'):
+                for url in object_item.get('urls'):
+                    self._add_result('chm_urls', url, {'item': object_item.get('name')})
+                object_item.pop('urls')
+
+        for object_item in obj_items_sumary:
+            if object_item.get('detection'):
+                for detection in object_item.get('detection'):
+                    self._add_result('chm_detection', detection, {'item': object_item.get('name')})
+                object_item.pop('detection')
+
+        for object_item in obj_items_summary:
+            name = object_item.pop('name')
+            self._add_result('chm_items', name, object_item)
+
+    def _parse_error(self, item, e):
+        self._error("Error parsing %s (%s): %s" % (item, e.__class__.__name__, e))

--- a/chminfo_service/__init__.py
+++ b/chminfo_service/__init__.py
@@ -11,8 +11,6 @@ from django.template.loader import render_to_string
 from crits.services.core import Service, ServiceConfigError
 from crits.samples.handlers import handle_file
 
-logger = logging.getLogger(__name__)
-
 class CHMInfoService(Service):
     """
     Microsoft Compiled HTML Help file information service

--- a/chminfo_service/__init__.py
+++ b/chminfo_service/__init__.py
@@ -5,7 +5,6 @@ import tempfile
 import HTMLParser
 import logging
 from chm import chm
-from contextlib import contextmanager
 
 from crits.services.core import Service, ServiceConfigError
 

--- a/chminfo_service/__init__.py
+++ b/chminfo_service/__init__.py
@@ -236,6 +236,3 @@ class CHMInfoService(Service):
 
         #Close file in memory
         self.chmparse.CloseCHM()
-
-    def _parse_error(self, item, e):
-        self._error("Error parsing %s (%s): %s" % (item, e.__class__.__name__, e))

--- a/chminfo_service/forms.py
+++ b/chminfo_service/forms.py
@@ -1,0 +1,12 @@
+from django import forms
+
+class CHMInfoRunForm(forms.Form):
+    error_css_class = 'error'
+    required_css_class = 'required'
+    chm_items = forms.BooleanField(required=False,
+                                  label="Items",
+                                  help_text="New samples from CHM Items (insert child pages).",
+                                  initial=True)
+
+    def __init__(self, *args, **kwargs):
+        super(CHMInfoRunForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Overview:
The CHMInfo service will analyse ITSF (.chm) files using the pychm and libchm libraries. The service extracts metadata and URLs from a sample and will also attempt to detect malicious behaviour.

Information provided by service:
- chm_overview: general metadata about the file i.e. title, pages and language information.
- chm_items_added: child item added to CRITS and details of each item (page) in the sample.
- chm_items: details of each item (page) in the sample, includes size and MD5.
- chm_detection: results from the detection code, includes detection rule and item (page) name.
- chm_urls: URLs and IP addresses extracted from the document using regex.

Comments:
- This has been tested against all of the samples I have at my disposal, if you have additional samples that may help improve the detection techniques, please let me know.

Future work:
- Improved detection techniques, pending additional samples.