### PR TITLE
peinfo_service - Fixed a case where unnamed exports would not be shown in service results. 

### DIFF
--- a/peinfo_service/__init__.py
+++ b/peinfo_service/__init__.py
@@ -37,7 +37,7 @@ class PEInfoService(Service):
     """
 
     name = "peinfo"
-    version = '1.1.3'
+    version = '1.1.4'
     supported_types = ['Sample']
     description = "Generate metadata about Windows PE/COFF files."
     added_files = []
@@ -267,7 +267,7 @@ class PEInfoService(Service):
                             "resource_id": i.id,
                             "language": x.lang,
                             "sub_language": x.sublang,
-                            "address": x.struct.OffsetToData,
+                            "address": hex(x.struct.OffsetToData),
                             "size": len(data),
                             "md5": hashlib.md5(data).hexdigest(),
                     }
@@ -287,7 +287,7 @@ class PEInfoService(Service):
                 if section_name == "":
                     section_name = "NULL"
                 data = {
-                        "virt_address": section.VirtualAddress,
+                        "virt_address": hex(section.VirtualAddress),
                         "virt_size": section.Misc_VirtualSize,
                         "size": section.SizeOfRawData,
                         "md5": section.get_hash_md5(),
@@ -310,6 +310,7 @@ class PEInfoService(Service):
                             "dll": "%s" % entry.dll,
                             "ordinal": "%s" % imp.ordinal,
                     }
+                    self._debug("import_data: '%s'" % data )
                     self._add_result('pe_import', name, data)
         except Exception as e:
             self._parse_error("imports", e)
@@ -317,9 +318,12 @@ class PEInfoService(Service):
     def _get_exports(self, pe):
         try:
             for entry in pe.DIRECTORY_ENTRY_EXPORT.symbols:
-                data = {"rva_offset": pe.OPTIONAL_HEADER.ImageBase
-                                        + entry.address}
-                self._add_result('pe_export', entry.name, data)
+                data = {"rva_offset": hex(pe.OPTIONAL_HEADER.ImageBase
+                                        + entry.address)}
+                ename = 'NULL'
+                if entry.name:
+                    ename = entry.name
+                self._add_result('pe_export', ename, data)
         except Exception as e:
             self._parse_error("exports", e)
 
@@ -342,7 +346,7 @@ class PEInfoService(Service):
                     result = {
                          'MajorVersion': dbg.struct.MajorVersion,
                          'MinorVersion': dbg.struct.MinorVersion,
-                         'PointerToRawData': dbg.struct.PointerToRawData,
+                         'PointerToRawData': hex(dbg.struct.PointerToRawData),
                          'SizeOfData': dbg.struct.SizeOfData,
                          'TimeDateStamp': dbg.struct.TimeDateStamp,
                          'TimeDateString': strftime('%Y-%m-%d %H:%M:%S', localtime(dbg.struct.TimeDateStamp)),


### PR DESCRIPTION
Besides fix for the unnamed exports, I've changed the display of some addresses to a more analyst-friendly hexadecimal base for peinfo_service.