### PR TITLE
Ubuntu 14.04 fixes

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -39,9 +39,9 @@ VER="$(echo "$VER" | tr "[:upper:]" "[:lower:]")"
 if [ "$OS" = 'ubuntu' ]
 then
   echo "Installing dependencies with apt-get"
+  sudo apt-add-repository universe
   sudo apt-get update
-  sudo apt-get install -y --fix-missing libchm1 clamav clamd freshclam wireshark
-  upx
+  sudo apt-get install -y --fix-missing libchm1 clamav upx wireshark
   sudo ldconfig
 
 # Redhat: Install as many dependencies as we can using yum.


### PR DESCRIPTION
To test this I booted Ubuntu 14.02 off an USB drive, installed git, cloned the crits_services repo.
The issues were:
- universe repo needs to be enabled or there is no libchm1, upx, wireshark.
- I've removed clamd freshclam packages that would cause errors and are installed anyway. 
- Upx was on a separate line, and not with the rest of apt-get install bunch.