### PR TITLE
Fix for broken syntax error handling through YARA

### DIFF
--- a/yara_service/handlers.py
+++ b/yara_service/handlers.py
@@ -46,5 +46,5 @@ def test_yara_rule(id_, rule):
                 yara_results.append("No matches!")
             message = pprint.pformat(yara_results)
         except SyntaxError, e:
-            message = "Syntax error in rule: %s" % e
+            message = "Syntax error in YARA rule: %s" % e
     return {"success": success, "message": message}

--- a/yara_service/handlers.py
+++ b/yara_service/handlers.py
@@ -45,6 +45,6 @@ def test_yara_rule(id_, rule):
             if mcount == 0:
                 yara_results.append("No matches!")
             message = pprint.pformat(yara_results)
-        except yara.SyntaxError, e:
+        except SyntaxError, e:
             message = "Syntax error in rule: %s" % e
     return {"success": success, "message": message}


### PR DESCRIPTION
The Python YARA module does not handle module owned syntax errors. These
are handled through the generic syntax error handler. This extremely
small patch fixes the issue in the current code.

Sending a broken YARA rule towards the current CRITS yara service
results in the following error (rather than the output of the broken
rule):

Traceback:
File
"/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py" in
get_response
112.                     response = wrapped_callback(request,
*callback_args, **callback_kwargs)
File
"/usr/local/lib/python2.7/dist-packages/django/contrib/auth/decorators.py"
in _wrapped_view
22.                 return view_func(request, *args, **kwargs)
File "/var/www/localhost/crits/services/views.py" in edit_config
141.         results = do_edit_config(name, analyst,
post_data=request.POST)
File "/var/www/localhost/crits/services/handlers.py" in
do_edit_config
526.                 service_class.parse_config(form.cleaned_data)
File "/var/www/localhost/crits_services/yara_service/__init__.py"
in parse_config
41.         YaraService._compile_rules(config['sigdir'],
config['sigfiles'])
File "/var/www/localhost/crits_services/yara_service/__init__.py"
in _compile_rules
168.             except yara.SyntaxError:

Exception Type: AttributeError at /services/edit/yara/
Exception Value: 'module' object has no attribute 'SyntaxError'

With the applied fix:
SyntaxError: Brokentest.yar(4): undefined identifier "ThisDoesNotExist"