### PR TITLE
Add CybOX/STIX to TAXII Service

### DIFF
--- a/metacap_service/handlers.py
+++ b/metacap_service/handlers.py
@@ -13,6 +13,8 @@ from crits.core.mongo_tools import get_file_gridfs, put_file_gridfs
 from crits.core.user_tools import get_user_organization
 from crits.services.handlers import get_config
 
+from crits.vocabulary.objects import ObjectTypes
+
 
 def pcap_tcpdump(pcap_md5, form, analyst):
     flag_list = []
@@ -195,8 +197,7 @@ def pcap_pdml_html(pcap_md5, analyst):
                     m = hashlib.md5()
                     m.update(pdml_html)
                     md5 = m.hexdigest()
-                    pcap.add_object("Artifact",
-                                    "File",
+                    pcap.add_object(ObjectTypes.FILE_UPLOAD,
                                     md5,
                                     get_user_organization(analyst),
                                     "MetaCap",

--- a/taxii_service/DEPENDENCIES
+++ b/taxii_service/DEPENDENCIES
@@ -2,3 +2,5 @@ The TAXII service requires:
 
 - M2Crypto
 - libtaxii-1.1.102 and its dependencies
+- cybox==2.1.0.11
+- stix==1.1.1.5

--- a/taxii_service/api.py
+++ b/taxii_service/api.py
@@ -1,0 +1,107 @@
+from django.core.urlresolvers import reverse
+from mongoengine import Document
+from tastypie import authorization
+from tastypie.authentication import MultiAuthentication
+from tastypie.exceptions import BadRequest
+
+from crits.standards.handlers import import_standards_doc
+from crits.core.api import CRITsApiKeyAuthentication, CRITsSessionAuthentication
+from crits.core.api import CRITsSerializer, CRITsAPIResource
+from crits.core.crits_mongoengine import CritsDocument
+
+
+class StandardsObject(CritsDocument, Document):
+    """
+    Class to store data if we ever decide to make this support GET
+    """
+
+class StandardsResource(CRITsAPIResource):
+    """
+    Class to handle everything related to the Standards API.
+
+    Currently supports  POST.
+    """
+
+    class Meta:
+        object_class = StandardsObject
+        allowed_methods = ('post',)
+        resource_name = "standards"
+        authentication = MultiAuthentication(CRITsApiKeyAuthentication(),
+                                             CRITsSessionAuthentication())
+        authorization = authorization.Authorization()
+        serializer = CRITsSerializer()
+
+
+    def obj_create(self, bundle, **kwargs):
+        """
+        Handles creating STIX documents through the API.
+
+        :param bundle: Bundle to create the records associated with this STIX document.
+        :type bundle: Tastypie Bundle object.
+        :returns: HttpResponse.
+        """
+
+        analyst = bundle.request.user.username
+        type_ = bundle.data.get('upload_type', None)
+
+        content = {'return_code': 1,
+                   'imported': [],
+                   'failed': []}
+
+        if not type_:
+            content['message'] = 'You must specify the upload type.'
+            self.crits_response(content)
+        elif type_ not in ('file', 'xml'):
+            content['message'] = 'Unknown or unsupported upload type. ' + type_
+            self.crits_response(content)
+
+        # Remove this so it doesn't get included with the fields upload
+        del bundle.data['upload_type']
+
+        # Extract common information
+        source = bundle.data.get('source', None)
+        method = bundle.data.get('method', None)
+        reference = bundle.data.get('reference', None)
+        me = bundle.data.get('make_event', False)  # default to False for the event
+
+        if not source:
+            content['message'] = 'No Source was specified'
+            self.crits_response(content)
+
+        if type_ == 'xml':
+            filedata = bundle.data.get('xml', None)
+        elif type_ == 'file':
+            file_ = bundle.data.get('filedata', None)
+            filedata = file_.read()
+        if not filedata:
+            content['message'] = 'No STIX content uploaded.'
+            self.crits_response(content)
+        result = import_standards_doc(filedata,
+                                      analyst,
+                                      method,
+                                      make_event = me,
+                                      ref = reference,
+                                      source = source)
+
+        if len(result['imported']):
+            for i in result['imported']:
+                d = {}
+                otype = i[0]
+                obj = i[1]
+                rname = self.resource_name_from_type(otype)
+                url = reverse('api_dispatch_detail',
+                            kwargs={'resource_name': rname,
+                                    'api_name': 'v1',
+                                    'pk': str(obj.id)})
+                d['url'] = url
+                d['type'] = otype
+                d['id'] = str(obj.id)
+                content['imported'].append(d)
+        if len(result['failed']):
+            for f in result['failed']:
+                d = {'type': f[1],
+                     'message': f[0]}
+                content['failed'].append(d)
+        if result['success']:
+            content['return_code'] = 0
+        self.crits_response(content)

--- a/taxii_service/forms.py
+++ b/taxii_service/forms.py
@@ -2,9 +2,8 @@
 # Source code distributed pursuant to license agreement.
 
 from django import forms
-from django.conf import settings
 
-from crits.core.user_tools import user_sources
+from crits.core.user_tools import user_sources, get_user_organization
 from crits.core.handlers import get_source_names, collect_objects
 from crits.core.class_mapper import class_from_type
 from crits.services.handlers import get_config
@@ -63,15 +62,17 @@ def filter_and_format_choices(choice_opts, item, _type):
     :param _type The type of objects represented in the choice_opts dict
     """
 
+    from .handlers import has_cybox_repr
+
     ret_opts = [] # return storage array
     item_type = item._meta['crits_type'] # get the type of the subject
     choice_fmt = formats.get_format(_type) # get the formatting option for the current CRITs type
     for choice in choice_opts:
         obj = choice_opts.get(choice)[1]
-        if _type == class_from_type("Indicator")._meta['crits_type'] and not obj.has_cybox_repr():
+        if _type == class_from_type("Indicator")._meta['crits_type'] and not has_cybox_repr(obj):
             # this indicator can't currently be converted to CybOX, so don't offer as option in UI
             continue
-        if item.id != obj.id or item_type != _type: 
+        if item.id != obj.id or item_type != _type:
             # only process if the item isn't the current context crits item
             ret_opts.append((choice, choice_fmt.format(obj)))
     return ret_opts
@@ -80,11 +81,14 @@ def get_supported_types():
     """
     Get a list of supported types for TAXII service.
     """
-    supported_types = []
-    for ctype in settings.CRITS_TYPES:
-        cls = class_from_type(ctype)
-        if hasattr(cls, "to_stix_indicator") or hasattr(cls, "to_cybox_observable"):
-            supported_types.append(ctype)
+    supported_types = ['Certificate',
+                       'Domain',
+                       'Email',
+                       'Indicator',
+                       'IP',
+                       'PCAP',
+                       'RawData',
+                       'Sample']
     return supported_types
 
 class TAXIIServiceConfigForm(forms.Form):
@@ -137,3 +141,24 @@ class TAXIIServiceConfigForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(TAXIIServiceConfigForm, self).__init__(*args, **kwargs)
+
+
+class UploadStandardsForm(forms.Form):
+    """
+    Django form for uploading a standards document.
+    """
+
+    error_css_class = 'error'
+    required_css_class = 'required'
+    filedata = forms.FileField()
+    source = forms.ChoiceField(required=True)
+    reference = forms.CharField(required=False)
+    make_event = forms.BooleanField(required=False, label="Create event", initial=True)
+
+    def __init__(self, username, *args, **kwargs):
+        super(UploadStandardsForm, self).__init__(*args, **kwargs)
+        self.fields['source'].choices = [(c.name,
+                                          c.name) for c in get_source_names(True,
+                                                                            True,
+                                                                            username)]
+        self.fields['source'].initial = get_user_organization(username)

--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -38,6 +38,8 @@ from crits.core.class_mapper import class_from_id, class_from_type
 from crits.core.crits_mongoengine import Releasability
 from crits.services.handlers import get_config
 
+from crits.vocabulary.ips import IPTypes
+
 logger = logging.getLogger(__name__)
 
 def execute_taxii_agent(hostname=None, https=None, feed=None, keyfile=None,
@@ -304,43 +306,20 @@ def to_cybox_observable(obj, exclude=None, bin_fmt="raw"):
         return (observables, obj.releasability)
     elif type_ == 'Indicator':
         observables = []
-
-        parts = obj.ind_type.split(' - ')
-        if len(parts) == 2:
-            (type_, name) = parts
-        else:
-            type_ = parts[0]
-            name = None
-        obje = make_cybox_object(type_, name, obj.value)
-
+        obje = make_cybox_object(obj.ind_type, obj.value)
         observables.append(Observable(obje))
         return (observables, obj.releasability)
     elif type_ == 'IP':
         obje = Address()
         obje.address_value = obj.ip
-
-        temp_type = obj.ip_type.replace("-", "")
-        if temp_type.find(Address.CAT_ASN.replace("-", "")) >= 0:
-            obje.category = Address.CAT_ASN
-        elif temp_type.find(Address.CAT_ATM.replace("-", "")) >= 0:
-            obje.category = Address.CAT_ATM
-        elif temp_type.find(Address.CAT_CIDR.replace("-", "")) >= 0:
-            obje.category = Address.CAT_CIDR
-        elif temp_type.find(Address.CAT_MAC.replace("-", "")) >= 0:
-            obje.category = Address.CAT_MAC
-        elif temp_type.find(Address.CAT_IPV4_NETMASK.replace("-", "")) >= 0:
-            obje.category = Address.CAT_IPV4_NETMASK
-        elif temp_type.find(Address.CAT_IPV4_NET.replace("-", "")) >= 0:
-            obje.category = Address.CAT_IPV4_NET
-        elif temp_type.find(Address.CAT_IPV4.replace("-", "")) >= 0:
-            obje.category = Address.CAT_IPV4
-        elif temp_type.find(Address.CAT_IPV6_NETMASK.replace("-", "")) >= 0:
-            obje.category = Address.CAT_IPV6_NETMASK
-        elif temp_type.find(Address.CAT_IPV6_NET.replace("-", "")) >= 0:
-            obje.category = Address.CAT_IPV6_NET
-        elif temp_type.find(Address.CAT_IPV6.replace("-", "")) >= 0:
-            obje.category = Address.CAT_IPV6
-
+        if obj.ip_type == IPTypes.IPv4_ADDRESS:
+            obje.category = "ipv4-addr"
+        elif obj.ip_type == IPTypes.IPv6_ADDRESS:
+            obje.category = "ipv6-addr"
+        elif obj.ip_type == IPTypes.IPv4_SUBNET:
+            obje.category = "ipv4-net"
+        elif obj.ip_type == IPTypes.IPv6_SUBNET:
+            obje.category = "ipv6-subnet"
         return ([Observable(obje)], obj.releasability)
     elif type_ == 'PCAP':
         obje = File()

--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -1,6 +1,9 @@
+import logging
+import os
 import pytz
 import socket
-import os
+import uuid
+
 from datetime import datetime
 from dateutil.parser import parse
 from dateutil.tz import tzutc
@@ -14,12 +17,28 @@ import libtaxii.messages_11 as tm11
 
 from django.conf import settings
 
+from cybox.common import String, DateTime, Hash, UnsignedLong
+from cybox.common.object_properties import CustomProperties, Property
+from cybox.core import Observable
+from cybox.objects.address_object import Address, EmailAddress
+from cybox.objects.artifact_object import Artifact, Base64Encoding, ZlibCompression
+from cybox.objects.domain_name_object import DomainName
+from cybox.objects.email_message_object import EmailHeader, EmailMessage, Attachments
+from cybox.objects.file_object import File
+
+from stix.threat_actor import ThreatActor
+
 from . import taxii
 from . import formats
+from .parsers import STIXParser, STIXParserException
+from .object_mapper import make_cybox_object
+
 from crits.events.event import Event
+from crits.core.class_mapper import class_from_id, class_from_type
 from crits.core.crits_mongoengine import Releasability
-from crits.standards.handlers import import_standards_doc
 from crits.services.handlers import get_config
+
+logger = logging.getLogger(__name__)
 
 def execute_taxii_agent(hostname=None, https=None, feed=None, keyfile=None,
                         certfile=None, start=None, end=None, analyst=None,
@@ -193,6 +212,423 @@ def parse_content_block(content_block, privkey=None, pubkey=None):
     else:
         return None
 
+
+def to_cybox_observable(obj, exclude=None, bin_fmt="raw"):
+    """
+    Convert a CRITs TLO to a CybOX Observable.
+
+    :param obj: The TLO to convert.
+    :type obj: :class:`crits.core.crits_mongoengine.CRITsBaseAttributes`
+    :param exclude: Attributes to exclude.
+    :type exclude: list
+    :param bin_fmt: The format for the binary (if applicable).
+    :type bin_fmt: str
+    """
+
+    type_ = obj._meta['crits_type']
+    if type_ == 'Certificate':
+        custom_prop = Property() # make a custom property so CRITs import can identify Certificate exports
+        custom_prop.name = "crits_type"
+        custom_prop.description = "Indicates the CRITs type of the object this CybOX object represents"
+        custom_prop._value = "Certificate"
+        obje = File() # represent cert information as file
+        obje.md5 = obj.md5
+        obje.file_name = obj.filename
+        obje.file_format = obj.filetype
+        obje.size_in_bytes = obj.size
+        obje.custom_properties = CustomProperties()
+        obje.custom_properties.append(custom_prop)
+        obs = Observable(obje)
+        obs.description = obj.description
+        data = obj.filedata.read()
+        if data: # if cert data available
+            a = Artifact(data, Artifact.TYPE_FILE) # create artifact w/data
+            a.packaging.append(Base64Encoding())
+            obje.add_related(a, "Child_Of") # relate artifact to file
+        return ([obs], obj.releasability)
+    elif type_ == 'Domain':
+        obje = DomainName()
+        obje.value = obj.domain
+        obje.type_ = obj.record_type
+        return ([Observable(obje)], obj.releasability)
+    elif type_ == 'Email':
+        if exclude == None:
+            exclude = []
+
+        observables = []
+
+        obje = EmailMessage()
+        # Assume there is going to be at least one header
+        obje.header = EmailHeader()
+
+        if 'message_id' not in exclude:
+            obje.header.message_id = String(obj.message_id)
+
+        if 'subject' not in exclude:
+            obje.header.subject = String(obj.subject)
+
+        if 'sender' not in exclude:
+            obje.header.sender = Address(obj.sender, Address.CAT_EMAIL)
+
+        if 'reply_to' not in exclude:
+            obje.header.reply_to = Address(obj.reply_to, Address.CAT_EMAIL)
+
+        if 'x_originating_ip' not in exclude:
+            obje.header.x_originating_ip = Address(obj.x_originating_ip,
+                                                  Address.CAT_IPV4)
+
+        if 'x_mailer' not in exclude:
+            obje.header.x_mailer = String(obj.x_mailer)
+
+        if 'boundary' not in exclude:
+            obje.header.boundary = String(obj.boundary)
+
+        if 'raw_body' not in exclude:
+            obje.raw_body = obj.raw_body
+
+        if 'raw_header' not in exclude:
+            obje.raw_header = obj.raw_header
+
+        #copy fields where the names differ between objects
+        if 'helo' not in exclude and 'email_server' not in exclude:
+            obje.email_server = String(obj.helo)
+        if ('from_' not in exclude and 'from' not in exclude and
+            'from_address' not in exclude):
+            obje.header.from_ = EmailAddress(obj.from_address)
+        if 'date' not in exclude and 'isodate' not in exclude:
+            obje.header.date = DateTime(obj.isodate)
+
+        obje.attachments = Attachments()
+
+        observables.append(Observable(obje))
+        return (observables, obj.releasability)
+    elif type_ == 'Indicator':
+        observables = []
+
+        parts = obj.ind_type.split(' - ')
+        if len(parts) == 2:
+            (type_, name) = parts
+        else:
+            type_ = parts[0]
+            name = None
+        obje = make_cybox_object(type_, name, obj.value)
+
+        observables.append(Observable(obje))
+        return (observables, obj.releasability)
+    elif type_ == 'IP':
+        obje = Address()
+        obje.address_value = obj.ip
+
+        temp_type = obj.ip_type.replace("-", "")
+        if temp_type.find(Address.CAT_ASN.replace("-", "")) >= 0:
+            obje.category = Address.CAT_ASN
+        elif temp_type.find(Address.CAT_ATM.replace("-", "")) >= 0:
+            obje.category = Address.CAT_ATM
+        elif temp_type.find(Address.CAT_CIDR.replace("-", "")) >= 0:
+            obje.category = Address.CAT_CIDR
+        elif temp_type.find(Address.CAT_MAC.replace("-", "")) >= 0:
+            obje.category = Address.CAT_MAC
+        elif temp_type.find(Address.CAT_IPV4_NETMASK.replace("-", "")) >= 0:
+            obje.category = Address.CAT_IPV4_NETMASK
+        elif temp_type.find(Address.CAT_IPV4_NET.replace("-", "")) >= 0:
+            obje.category = Address.CAT_IPV4_NET
+        elif temp_type.find(Address.CAT_IPV4.replace("-", "")) >= 0:
+            obje.category = Address.CAT_IPV4
+        elif temp_type.find(Address.CAT_IPV6_NETMASK.replace("-", "")) >= 0:
+            obje.category = Address.CAT_IPV6_NETMASK
+        elif temp_type.find(Address.CAT_IPV6_NET.replace("-", "")) >= 0:
+            obje.category = Address.CAT_IPV6_NET
+        elif temp_type.find(Address.CAT_IPV6.replace("-", "")) >= 0:
+            obje.category = Address.CAT_IPV6
+
+        return ([Observable(obje)], obj.releasability)
+    elif type_ == 'PCAP':
+        obje = File()
+        obje.md5 = obj.md5
+        obje.file_name = obj.filename
+        obje.file_format = obj.contentType
+        obje.size_in_bytes = obj.length
+        obs = Observable(obje)
+        obs.description = obj.description
+        art = Artifact(obj.filedata.read(), Artifact.TYPE_NETWORK)
+        art.packaging.append(Base64Encoding())
+        obje.add_related(art, "Child_Of") # relate artifact to file
+        return ([obs], obj.releasability)
+    elif type_ == 'RawData':
+        obje = Artifact(obj.data.encode('utf-8'), Artifact.TYPE_FILE)
+        obje.packaging.append(Base64Encoding())
+        obs = Observable(obje)
+        obs.description = obj.description
+        return ([obs], obj.releasability)
+    elif type_ == 'Sample':
+        if exclude == None:
+            exclude = []
+
+        observables = []
+        f = File()
+        for attr in ['md5', 'sha1', 'sha256']:
+            if attr not in exclude:
+                val = getattr(obj, attr, None)
+                if val:
+                    setattr(f, attr, val)
+        if obj.ssdeep and 'ssdeep' not in exclude:
+            f.add_hash(Hash(obj.ssdeep, Hash.TYPE_SSDEEP))
+        if 'size' not in exclude and 'size_in_bytes' not in exclude:
+            f.size_in_bytes = UnsignedLong(obj.size)
+        if 'filename' not in exclude and 'file_name' not in exclude:
+            f.file_name = obj.filename
+        # create an Artifact object for the binary if it exists
+        if 'filedata' not in exclude and bin_fmt:
+            data = obj.filedata.read()
+            if data: # if sample data available
+                a = Artifact(data, Artifact.TYPE_FILE) # create artifact w/data
+                if bin_fmt == "zlib":
+                    a.packaging.append(ZlibCompression())
+                    a.packaging.append(Base64Encoding())
+                elif bin_fmt == "base64":
+                    a.packaging.append(Base64Encoding())
+                f.add_related(a, "Child_Of") # relate artifact to file
+        if 'filetype' not in exclude and 'file_format' not in exclude:
+            #NOTE: this doesn't work because the CybOX File object does not
+            #   have any support built in for setting the filetype to a
+            #   CybOX-binding friendly object (e.g., calling .to_dict() on
+            #   the resulting CybOX object fails on this field.
+            f.file_format = obj.filetype
+        observables.append(Observable(f))
+        return (observables, obj.releasability)
+    else:
+        return (None, None)
+
+def to_stix_indicator(obj):
+    """
+    Creates a STIX Indicator object from a CybOX object.
+
+    Returns the STIX Indicator and the original CRITs object's
+    releasability list.
+    """
+    from stix.indicator import Indicator as S_Ind
+    from stix.common.identity import Identity
+    ind = S_Ind()
+    obs, releas = to_cybox_observable(obj)
+    for ob in obs:
+        ind.add_observable(ob)
+    #TODO: determine if a source wants its name shared. This will
+    #   probably have to happen on a per-source basis rather than a per-
+    #   object basis.
+    identity = Identity(name=settings.COMPANY_NAME)
+    ind.set_producer_identity(identity)
+
+    return (ind, releas)
+
+def to_stix_actor(obj):
+    """
+    Create a STIX Actor.
+    """
+
+    ta = ThreatActor()
+    ta.title = obj.name
+    ta.description = obj.description
+    for tt in obj.threat_types:
+        ta.add_type(tt)
+    for m in obj.motivations:
+        ta.add_motivation(m)
+    for ie in obj.intended_effects:
+        ta.add_intended_effect(ie)
+    for s in obj.sophistications:
+        ta.add_sophistication(s)
+    #for i in self.identifiers:
+    return (ta, obj.releasability)
+
+def to_stix_incident(obj):
+    """
+    Creates a STIX Incident object from a CRITs Event.
+
+    Returns the STIX Incident and the original CRITs Event's
+    releasability list.
+    """
+    from stix.incident import Incident
+    inc = Incident(title=obj.title, description=obj.description)
+
+    return (inc, obj.releasability)
+
+def has_cybox_repr(obj):
+    """
+    Determine if this indicator is of a type that can
+    successfully be converted to a CybOX object.
+
+    :return The CybOX representation if possible, else False.
+    """
+    try:
+        rep = make_cybox_object(obj)
+        return rep
+    except:
+        return False
+
+def to_stix(obj, items_to_convert=[], loaded=False, bin_fmt="raw"):
+    """
+    Converts a CRITs object to a STIX document.
+
+    The resulting document includes standardized representations
+    of all related objects noted within items_to_convert.
+
+    :param items_to_convert: The list of items to convert to STIX/CybOX
+    :type items_to_convert: Either a list of CRITs objects OR
+                            a list of {'_type': CRITS_TYPE, '_id': CRITS_ID} dicts
+    :param loaded: Set to True if you've passed a list of CRITs objects as
+                    the value for items_to_convert, else leave False.
+    :type loaded: bool
+    :param bin_fmt: Specifies the format for Sample data encoding.
+                    Options: None (don't include binary data in STIX output),
+                                "raw" (include binary data as is),
+                                "base64" (base64 encode binary data)
+
+    :returns: A dict indicating which items mapped to STIX indicators, ['stix_indicators']
+                which items mapped to STIX observables, ['stix_observables']
+                which items are included in the resulting STIX doc, ['final_objects']
+                and the STIX doc itself ['stix_obj'].
+    """
+
+    from cybox.common import Time, ToolInformationList, ToolInformation
+    from stix.common import StructuredText, InformationSource
+    from stix.core import STIXPackage, STIXHeader
+    from stix.common.identity import Identity
+
+    # These lists are used to determine which CRITs objects
+    # go in which part of the STIX document.
+    ind_list = ['Indicator']
+    obs_list = ['Certificate',
+                'Domain',
+                'Email',
+                'IP',
+                'PCAP',
+                'RawData',
+                'Sample']
+    actor_list = ['Actor']
+
+    # Store message
+    stix_msg = {
+                    'stix_incidents': [],
+                    'stix_indicators': [],
+                    'stix_observables': [],
+                    'stix_actors': [],
+                    'final_objects': []
+                }
+
+    if not loaded: # if we have a list of object metadata, load it before processing
+        items_to_convert = [class_from_id(item['_type'], item['_id'])
+                                for item in items_to_convert]
+
+    # add self to the list of items to STIXify
+    if obj not in items_to_convert:
+        items_to_convert.append(obj)
+
+    # add any email attachments
+    attachments = []
+    for obj in items_to_convert:
+        if obj._meta['crits_type'] == 'Email':
+            for rel in obj.relationships:
+                if rel.relationship == 'Contains':
+                    atch = class_from_id('Sample', rel.object_id)
+                    if atch not in items_to_convert:
+                        attachments.append(atch)
+    items_to_convert.extend(attachments)
+
+    # grab ObjectId of items
+    refObjs = {key.id: 0 for key in items_to_convert}
+
+    relationships = {}
+    stix = []
+    from stix.indicator import Indicator as S_Ind
+    for obj in items_to_convert:
+        obj_type = obj._meta['crits_type']
+        if obj_type == class_from_type('Event')._meta['crits_type']:
+            stx, release = to_stix_incident(obj)
+            stix_msg['stix_incidents'].append(stx)
+        elif obj_type in ind_list: # convert to STIX indicators
+            stx, releas = to_stix_indicator(obj)
+            stix_msg['stix_indicators'].append(stx)
+            refObjs[obj.id] = S_Ind(idref=stx.id_)
+        elif obj_type in obs_list: # convert to CybOX observable
+            if obj_type == class_from_type('Sample')._meta['crits_type']:
+                stx, releas = to_cybox_observable(obj, bin_fmt=bin_fmt)
+            else:
+                stx, releas = to_cybox_observable(obj)
+
+            # wrap in stix Indicator
+            ind = S_Ind()
+            for ob in stx:
+                ind.add_observable(ob)
+            ind.title = "CRITs %s Top-Level Object" % obj_type
+            ind.description = ("This is simply a CRITs %s top-level "
+                                "object, not actually an Indicator. "
+                                "The Observable is wrapped in an Indicator"
+                                " to facilitate documentation of the "
+                                "relationship." % obj_type)
+            ind.confidence = 'None'
+            stx = ind
+            stix_msg['stix_indicators'].append(stx)
+            refObjs[obj.id] = S_Ind(idref=stx.id_)
+        elif obj_type in actor_list: # convert to STIX actor
+            stx, releas = to_stix_actor(obj)
+            stix_msg['stix_actors'].append(stx)
+
+        # get relationships from CRITs objects
+        for rel in obj.relationships:
+            if rel.object_id in refObjs:
+                relationships.setdefault(stx.id_, {})
+                relationships[stx.id_][rel.object_id] = (rel.relationship,
+                                                            rel.rel_confidence.capitalize(),
+                                                            rel.rel_type)
+
+        stix_msg['final_objects'].append(obj)
+        stix.append(stx)
+
+    # set relationships on STIX objects
+    for stix_obj in stix:
+        for rel in relationships.get(stix_obj.id_, {}):
+            if isinstance(refObjs.get(rel), S_Ind): # if is STIX Indicator
+                stix_obj.related_indicators.append(refObjs[rel])
+                rel_meta = relationships.get(stix_obj.id_)[rel]
+                stix_obj.related_indicators[-1].relationship = rel_meta[0]
+                stix_obj.related_indicators[-1].confidence = rel_meta[1]
+
+                # Add any Email Attachments to CybOX EmailMessage Objects
+                if isinstance(stix_obj, S_Ind):
+                    if 'EmailMessage' in stix_obj.observable.object_.id_:
+                        if rel_meta[0] == 'Contains' and rel_meta[2] == 'Sample':
+                            email = stix_obj.observable.object_.properties
+                            email.attachments.append(refObjs[rel].idref)
+
+    tool_list = ToolInformationList()
+    tool = ToolInformation("CRITs", "MITRE")
+    tool.version = settings.CRITS_VERSION
+    tool_list.append(tool)
+    i_s = InformationSource(
+        time=Time(produced_time= datetime.now()),
+        identity=Identity(name=settings.COMPANY_NAME),
+        tools=tool_list)
+
+    if obj._meta['crits_type'] == "Event":
+        stix_desc = obj.description()
+        stix_int = obj.event_type()
+        stix_title = obj.title()
+    else:
+        stix_desc = "STIX from %s" % settings.COMPANY_NAME
+        stix_int = "Collective Threat Intelligence"
+        stix_title = "Threat Intelligence Sharing"
+    header = STIXHeader(information_source=i_s,
+                        description=StructuredText(value=stix_desc),
+                        package_intents=[stix_int],
+                        title=stix_title)
+
+    stix_msg['stix_obj'] = STIXPackage(incidents=stix_msg['stix_incidents'],
+                    indicators=stix_msg['stix_indicators'],
+                    threat_actors=stix_msg['stix_actors'],
+                    stix_header=header,
+                    id_=uuid.uuid4())
+
+    return stix_msg
+
 def run_taxii_service(analyst, obj, rcpts, preview, relation_choices=[], confirmed=False):
     """
     :param analyst The analyst triggering this TAXII service call
@@ -252,7 +688,7 @@ def run_taxii_service(analyst, obj, rcpts, preview, relation_choices=[], confirm
     # each/any recipient feed successfully.
 
     # Convert object and chosen related items to STIX/CybOX
-    stix_msg = obj.to_stix(relation_choices, bin_fmt="base64")
+    stix_msg = to_stix(obj, relation_choices, bin_fmt="base64")
     stix_doc = stix_msg['stix_obj']
 
     # if doing a preview of content, return content now
@@ -480,3 +916,53 @@ def encrypt_block(blob, pubkey):
     s.write(temp_buff, p7)
     x = temp_buff.read()
     return x
+
+def import_standards_doc(data, analyst, method, ref=None, make_event=False,
+                         source=None):
+    """
+    Import a standards document into CRITs.
+
+    :param data: The document data to feed into
+                 :class:`crits.standards.parsers.STIXParser`
+    :type data: str
+    :param analyst: The user importing the document.
+    :type analyst: str
+    :param method: The method of acquiring this document.
+    :type method: str
+    :param ref: The reference to this document.
+    :type ref: str
+    :param make_event: Whether or not we should make an Event for this document.
+    :type make_event: bool
+    :param source: The name of the source who provided this document.
+    :type source: str
+    :returns: dict with keys:
+              "success" (boolean),
+              "reason" (str),
+              "imported" (list),
+              "failed" (list)
+    """
+
+    ret = {
+            'success': False,
+            'reason': '',
+            'imported': [],
+            'failed': []
+          }
+
+    try:
+        parser = STIXParser(data, analyst, method)
+        parser.parse_stix(reference=ref, make_event=make_event, source=source)
+        parser.relate_objects()
+    except STIXParserException, e:
+        logger.exception(e)
+        ret['reason'] = str(e.message)
+        return ret
+    except Exception, e:
+        logger.exception(e)
+        ret['reason'] = str(e)
+        return ret
+
+    ret['imported'] = parser.imported
+    ret['failed'] = parser.failed
+    ret['success'] = True
+    return ret

--- a/taxii_service/object_mapper.py
+++ b/taxii_service/object_mapper.py
@@ -1,48 +1,26 @@
 from crits.core.crits_mongoengine import EmbeddedObject
+from crits.vocabulary.indicators import IndicatorTypes
+from crits.vocabulary.ips import IPTypes
+from crits.vocabulary.events import EventTypes
+from crits.vocabulary.actors import (
+    ThreatTypes,
+    Sophistications,
+    Motivations,
+    IntendedEffects
+)
 
-from cybox.common import String, PositiveInteger, StructuredText
-from cybox.common.object_properties import CustomProperties, Property
+from cybox.common import String, PositiveInteger
 
 from cybox.objects.account_object import Account
 from cybox.objects.address_object import Address
 from cybox.objects.api_object import API
-from cybox.objects.artifact_object import Artifact
-from cybox.objects.code_object import Code
-from cybox.objects.custom_object import Custom
-from cybox.objects.disk_object import Disk
-from cybox.objects.disk_partition_object import DiskPartition
 from cybox.objects.domain_name_object import DomainName
-from cybox.objects.dns_query_object import DNSQuery, DNSQuestion, DNSRecord
-from cybox.objects.email_message_object import EmailMessage
-from cybox.objects.gui_dialogbox_object import GUIDialogbox
-from cybox.objects.gui_window_object import GUIWindow
 from cybox.objects.http_session_object import HTTPRequestHeaderFields
-from cybox.objects.library_object import Library
-from cybox.objects.memory_object import Memory
 from cybox.objects.mutex_object import Mutex
-from cybox.objects.network_connection_object import NetworkConnection
-from cybox.objects.pipe_object import Pipe
 from cybox.objects.port_object import Port
 from cybox.objects.process_object import Process
-from cybox.objects.system_object import System
 from cybox.objects.uri_object import URI
-from cybox.objects.user_account_object import UserAccount
-from cybox.objects.volume_object import Volume
-from cybox.objects.win_driver_object import WinDriver
-from cybox.objects.win_event_object import WinEvent
-from cybox.objects.win_event_log_object import WinEventLog
-from cybox.objects.win_handle_object import WinHandle
-from cybox.objects.win_kernel_hook_object import WinKernelHook
-from cybox.objects.win_mailslot_object import WinMailslot
-from cybox.objects.win_network_share_object import WinNetworkShare
-from cybox.objects.win_process_object import WinProcess
 from cybox.objects.win_registry_key_object import WinRegistryKey
-from cybox.objects.win_service_object import WinService
-from cybox.objects.win_system_object import WinSystem
-from cybox.objects.win_task_object import WinTask
-from cybox.objects.win_user_object import WinUser
-from cybox.objects.win_volume_object import WinVolume
-from cybox.objects.x509_certificate_object import X509Certificate
 
 class UnsupportedCybOXObjectTypeError(Exception):
     """
@@ -74,213 +52,208 @@ def get_object_values(obj):
     except:
         return [obj.value]
 
-def make_cybox_object(type_, name=None, value=None):
+def get_crits_ip_type(type_):
+    if type_ == 'ipv4-addr':
+        return IPTypes.IPv4_ADDRESS
+    elif type_ == 'ipv6-addr':
+        return IPTypes.IPv6_ADDRESS
+    elif type_ == 'ipv4-net':
+        return IPTypes.IPv4_SUBNET
+    elif type_ == 'ipv6-net':
+        return IPTypes.IPv6_SUBNET
+    else:
+        return None
+
+def get_crits_event_type(type_):
+    """
+    Currently I am not sure what the best matches are and I think it's best to
+    leave this up to CybOX/STIX people to map to CRITs vocabulary.
+    """
+
+    return EventTypes.INTEL_SHARING
+
+def get_crits_actor_tags(type_):
+    if type_ == "Innovator":
+        return Sophistications.INNOVATOR
+    elif type_ == "Expert":
+        return Sophistications.EXPERT
+    elif type_ == "Practitioner":
+        return Sophistications.PRACTITIONER
+    elif type_ == "Novice":
+        return Sophistications.NOVICE
+    elif type_ == "Aspirant":
+        return Sophistications.ASPIRANT
+    elif type_ == "Ideological - Anti-Corruption":
+        return Motivations.ANTI_CORRUPTION
+    elif type_ == "Ideological - Anti-Establishment":
+        return Motivations.ANTI_ESTABLISHMENT
+    elif type_ == "Ideological - Environmental":
+        return Motivations.ENVIRONMENTAL
+    elif type_ == "Ideological - Ethnic / Nationalist":
+        return Motivations.ETHNIC_NATIONALIST
+    elif type_ == "Ideological - Information Freedom":
+        return Motivations.INFORMATION_FREEDOM
+    elif type_ == "Ideological - Religious":
+        return Motivations.RELIGIOUS
+    elif type_ == "Ideological - Security Awareness":
+        return Motivations.SECURITY_AWARENESS
+    elif type_ == "Ideological - Human Rights":
+        return Motivations.HUMAN_RIGHTS
+    elif type_ == "Ego":
+        return Motivations.EGO
+    elif type_ == "Financial or Economic":
+        return Motivations.FINANCIAL_OR_ECONOMIC
+    elif type_ == "Military":
+        return Motivations.MILITARY
+    elif type_ == "Opportunistic":
+        return Motivations.OPPORTUNISTIC
+    elif type_ == "Political":
+        return Motivations.POLITICAL
+    elif type_ == "Advantage - Economic":
+        return IntendedEffects.ECONOMIC
+    elif type_ == "Advantage - Military":
+        return IntendedEffects.MILITARY
+    elif type_ == "Advantage - Political":
+        return IntendedEffects.POLITICAL
+    elif type_ == "Theft - Intellectual Property":
+        return IntendedEffects.INTELLECTUAL_PROPERTY
+    elif type_ == "Theft - Credential Theft":
+        return IntendedEffects.CREDENTIAL_THEFT
+    elif type_ == "Theft - Identity Theft":
+        return IntendedEffects.IDENTITY_THEFT
+    elif type_ == "Theft - Theft of Proprietary Information":
+        return IntendedEffects.PROPRIETARY_INFORMATION
+    elif type_ == "Account Takeover":
+        return IntendedEffects.ACCOUNT_TAKEOVER
+    elif type_ == "Brand Damage":
+        return IntendedEffects.BRAND_DAMAGE
+    elif type_ == "Competitive Advantage":
+        return IntendedEffects.COMPETITIVE_ADVANTAGE
+    elif type_ == "Degredation of Service":
+        return IntendedEffects.DEGREDATION_OF_SERVICE
+    elif type_ == "Denial and Deception":
+        return IntendedEffects.DENIAL_AND_DECEPTION
+    elif type_ == "Destruction":
+        return IntendedEffects.DESTRUCTION
+    elif type_ == "Disruption":
+        return IntendedEffects.DISRUPTION
+    elif type_ == "Embarrassment":
+        return IntendedEffects.EMBARRASSMENT
+    elif type_ == "Exposure":
+        return IntendedEffects.EXPOSURE
+    elif type_ == "Extortion":
+        return IntendedEffects.EXTORTION
+    elif type_ == "Fraud":
+        return IntendedEffects.FRAUD
+    elif type_ == "Harassment":
+        return IntendedEffects.HARASSMENT
+    elif type_ == "ICS Control":
+        return IntendedEffects.IC_CONTROL
+    elif type_ == "Traffic Diversion":
+        return IntendedEffects.TRAFFIC_DIVERSION
+    elif type_ == "Unauthorized Access":
+        return IntendedEffects.UNAUTHORIZED_ACCESS
+    elif type_ == "Cyber Espionage Operations":
+        return ThreatTypes.CYBER_ESPIONAGE_OPERATIONS
+    elif type_ == "Hacker - White hat":
+        return ThreatTypes.HACKER_WHITE_HAT
+    elif type_ == "Hacker - Gray hat":
+        return ThreatTypes.HACKER_GRAY_HAT
+    elif type_ == "Hacker - Black hat":
+        return ThreatTypes.HACKER_BLACK_HAT
+    elif type_ == "Hacktivist":
+        return ThreatTypes.HACKTIVIST
+    elif type_ == "State Actor / Agency":
+        return ThreatTypes.STATE_ACTOR_AGENCY
+    elif type_ == "eCrime Actor - Credential Theft Botnet Operator":
+        return ThreatTypes.CREDENTIAL_THEFT_BOTNET_OPERATOR
+    elif type_ == "eCrime Actor - Credential Theft Botnet Service":
+        return ThreatTypes.CREDENTIAL_THEFT_BOTNET_SERVICE
+    elif type_ == "eCrime Actor - Malware Developer":
+        return ThreatTypes.MALWARE_DEVELOPER
+    elif type_ == "eCrime Actor - Money Laundering Network":
+        return ThreatTypes.MONEY_LAUNDERING_NETWORK
+    elif type_ == "eCrime Actor - Organized Crime Actor":
+        return ThreatTypes.ORGANIZED_CRIME
+    elif type_ == "eCrime Actor - Spam Service":
+        return ThreatTypes.SPAM_SERVICE
+    elif type_ == "eCrime Actor - Traffic Service":
+        return ThreatTypes.TRAFFIC_SERVICE
+    elif type_ == "eCrime Actor - Underground Call Service":
+        return ThreatTypes.UNDERGROUND_CALL_SERVICE
+    elif type_ == "Insider Threat":
+        return ThreatTypes.INSIDER_THREAT
+    elif type_ == "Disgrunted Customer / User":
+        return ThreatTypes.DISGRUNTLED_CUSTOMER_USER
+    else:
+        return None
+
+def make_cybox_object(type_, value=None):
     """
     Converts type_, name, and value to a CybOX object instance.
 
     :param type_: The object type.
     :type type_: str
-    :param name: The object name.
-    :type name: str
     :param value: The object value.
     :type value: str
     :returns: CybOX object
     """
 
-    if type_ == "Account":
+    if type_ == IndicatorTypes.USER_ID:
         acct = Account()
         acct.description = value
         return acct
-    elif type_ == "Address":
+    elif type_ in IPTypes.values():
+        if type_ == IPTypes.IPv4_ADDRESS:
+            name = 'ipv4-addr'
+        elif type_ == IPTypes.IPv6_ADDRESS:
+            name = 'ipv6-addr'
+        elif type_ == IPTypes.IPv4_SUBNET:
+            name = 'ipv4-net'
+        elif type_ == IPTypes.IPv6_SUBNET:
+            name = 'ipv6-net'
         return Address(category=name, address_value=value)
-    elif type_ == "Email Message":
-        e = EmailMessage()
-        e.raw_body = value
-        return e
-    elif type_ == "API":
+    elif type_ == IndicatorTypes.API_KEY:
         api = API()
         api.description = value
         return api
-    elif type_ == "Artifact":
-        if name == "Data Region":
-            atype = Artifact.TYPE_GENERIC
-        elif name == 'FileSystem Fragment':
-            atype = Artifact.TYPE_FILE_SYSTEM
-        elif name == 'Memory Region':
-            atype = Artifact.TYPE_MEMORY
-        else:
-            raise UnsupportedCybOXObjectTypeError(type_, name)
-        return Artifact(value, atype)
-    elif type_ == "Code":
-        obj = Code()
-        obj.code_segment = value
-        obj.type = name
-        return obj
-    elif type_ == "Disk":
-        disk = Disk()
-        disk.disk_name = type_
-        disk.type = name
-        return disk
-    elif type_ == "Disk Partition":
-        disk = DiskPartition()
-        disk.device_name = type_
-        disk.type = name
-        return disk
-    elif type_ == "DNS Query":
-        r = URI()
-        r.value = value
-        dq = DNSQuestion()
-        dq.qname = r
-        d = DNSQuery()
-        d.question = dq
-        return d
-    elif type_ == "DNS Record":
-        # DNS Record indicators in CRITs are just a free form text box, there
-        # is no good way to map them into the attributes of a DNSRecord cybox
-        # object. So just stuff it in the description until someone tells me
-        # otherwise.
-        d = StructuredText(value=value)
-        dr = DNSRecord()
-        dr.description = d
-        return dr
-    elif type_ == "GUI Dialogbox":
-        obj = GUIDialogbox()
-        obj.box_text = value
-        return obj
-    elif type_ == "GUI Window":
-        obj = GUIWindow()
-        obj.window_display_name = value
-        return obj
-    elif type_ == "HTTP Request Header Fields" and name and name == "User-Agent":
-        # TODO/NOTE: HTTPRequestHeaderFields has a ton of fields for info.
-        #    we should revisit this as UI is reworked or CybOX is improved.
+    elif type_ == IndicatorTypes.DOMAIN:
+        obj = DomainName()
+        obj.value = value
+    elif type_ == IndicatorTypes.USER_AGENT:
         obj = HTTPRequestHeaderFields()
         obj.user_agent = value
         return obj
-    elif type_ == "Library":
-        obj = Library()
-        obj.name = value
-        obj.type = name
-        return obj
-    elif type_ == "Memory":
-        obj = Memory()
-        obj.memory_source = value
-        return obj
-    elif type_ == "Mutex":
+    elif type_ == IndicatorTypes.MUTEX:
         m = Mutex()
         m.named = True
         m.name = String(value)
         return m
-    elif type_ == "Network Connection":
-        obj = NetworkConnection()
-        obj.layer7_protocol = value
-        return obj
-    elif type_ == "Pipe":
-        p = Pipe()
-        p.named = True
-        p.name = String(value)
-        return p
-    elif type_ == "Port":
+    elif type_ in (IndicatorTypes.SOURCE_PORT,
+                   IndicatorTypes.DEST_PORT):
         p = Port()
         try:
             p.port_value = PositiveInteger(value)
         except ValueError: # XXX: Raise a better exception...
             raise UnsupportedCybOXObjectTypeError(type_, name)
         return p
-    elif type_ == "Process":
+    elif type_ == IndicatorTypes.PROCESS_NAME:
         p = Process()
         p.name = String(value)
         return p
-    elif type_ == "String":
-        c = Custom()
-        c.custom_name = "crits:String"
-        c.description = ("This is a generic string used as the value of an "
-                         "Indicator or Object within CRITs.")
-        c.custom_properties = CustomProperties()
-
-        p1 = Property()
-        p1.name = "value"
-        p1.description = "Generic String"
-        p1.value = value
-        c.custom_properties.append(p1)
-        return c
-    elif type_ == "System":
-        s = System()
-        s.hostname = String(value)
-        return s
-    elif type_ == "URI":
+    elif type_ == IndicatorTypes.URI:
         r = URI()
         r.type_ = name
         r.value = value
         return r
-    elif type_ == "User Account":
-        obj = UserAccount()
-        obj.username = value
-        return obj
-    elif type_ == "Volume":
-        obj = Volume()
-        obj.name = value
-        return obj
-    elif type_ == "Win Driver":
-        w = WinDriver()
-        w.driver_name = String(value)
-        return w
-    elif type_ == "Win Event Log":
-        obj = WinEventLog()
-        obj.log = value
-        return obj
-    elif type_ == "Win Event":
-        w = WinEvent()
-        w.name = String(value)
-        return w
-    elif type_ == "Win Handle":
-        obj = WinHandle()
-        obj.type_ = name
-        obj.object_address = value
-        return obj
-    elif type_ == "Win Kernel Hook":
-        obj = WinKernelHook()
-        obj.description = value
-        return obj
-    elif type_ == "Win Mailslot":
-        obj = WinMailslot()
-        obj.name = value
-        return obj
-    elif type_ == "Win Network Share":
-        obj = WinNetworkShare()
-        obj.local_path = value
-        return obj
-    elif type_ == "Win Process":
-        obj = WinProcess()
-        obj.window_title = value
-        return obj
-    elif type_ == "Win Registry Key":
+    elif type_ in (IndicatorTypes.REGISTRY_KEY,
+                   IndicatorTypes.REG_KEY_CREATED,
+                   IndicatorTypes.REG_KEY_DELETED,
+                   IndicatorTypes.REG_KEY_ENUMERATED,
+                   IndicatorTypes.REG_KEY_MONITORED,
+                   IndicatorTypes.REG_KEY_OPENED):
         obj = WinRegistryKey()
         obj.key = value
-        return obj
-    elif type_ == "Win Service":
-        obj = WinService()
-        obj.service_name = value
-        return obj
-    elif type_ == "Win System":
-        obj = WinSystem()
-        obj.product_name = value
-        return obj
-    elif type_ == "Win Task":
-        obj = WinTask()
-        obj.name = value
-        return obj
-    elif type_ == "Win User Account":
-        obj = WinUser()
-        obj.security_id = value
-        return obj
-    elif type_ == "Win Volume":
-        obj = WinVolume()
-        obj.drive_letter = value
-        return obj
-    elif type_ == "X509 Certificate":
-        obj = X509Certificate()
-        obj.raw_certificate = value
         return obj
     """
     The following are types that are listed in the 'Indicator Type' box of
@@ -340,180 +313,49 @@ def make_crits_object(cybox_obj):
     o = EmbeddedObject()
     o.datatype = "string"
     if isinstance(cybox_obj, Account):
-        o.object_type = "Account"
+        o.object_type = IndicatorTypes.USER_ID
         o.value = get_object_values(cybox_obj.description)
         return o
     elif isinstance(cybox_obj, Address):
-        o.object_type = "Address"
-        o.name = str(cybox_obj.category)
+        name = str(cybox_obj.category)
+        if name == 'ipv4-addr':
+            o.object_type = IPTypes.IPv4_ADDRESS
+        elif name == 'ipv6-addr':
+            o.object_type = IPTypes.IPv6_ADDRESS
+        elif name == 'ipv4-net':
+            o.object_type = IPTypes.IPv4_SUBNET
+        elif name == 'ipv6-net':
+            o.object_type = IPTypes.IPv6_SUBNET
         o.value = get_object_values(cybox_obj.address_value)
         return o
     elif isinstance(cybox_obj, API):
-        o.object_type = "API"
-        o.value = get_object_values(cybox_obj.description)
-        return o
-    elif isinstance(cybox_obj, Artifact):
-        o.object_type = "Artifact"
-        o.value = [cybox_obj.data]
-        if cybox_obj.type_ == Artifact.TYPE_GENERIC:
-            o.name = "Data Region"
-            return o
-        elif cybox_obj.type_ == Artifact.TYPE_FILE_SYSTEM:
-            o.name = "FileSystem Fragment"
-            return o
-        elif cybox_obj.type_ == Artifact.TYPE_MEMORY:
-            o.name = "Memory Region"
-            return o
-    elif isinstance(cybox_obj, Code):
-        o.object_type = "Code"
-        o.name = str(cybox_obj.type)
-        o.value = get_object_values(cybox_obj.code_segment)
-        return o
-    elif isinstance(cybox_obj, Custom):
-        if cybox_obj.custom_name == "crits:String":
-            if cybox_obj.custom_properties[0].name == "value":
-                o.object_type = "String"
-                o.value = [cybox_obj.custom_properties[0].value]
-                return o
-    elif isinstance(cybox_obj, Disk):
-        o.object_type = "Disk"
-        o.name = str(cybox_obj.type)
-        o.value = get_object_values(cybox_obj.disk_name)
-        return o
-    elif isinstance(cybox_obj, DiskPartition):
-        o.object_type = "Disk Partition"
-        o.name = str(cybox_obj.type)
-        o.value = get_object_values(cybox_obj.device_name)
-        return o
-    elif isinstance(cybox_obj, DNSQuery):
-        o.object_type = "DNS Query"
-        o.value = get_object_values(cybox_obj.question.qname)
-        return o
-    elif isinstance(cybox_obj, DNSRecord):
-        o.object_type = "DNS Record"
+        o.object_type = IndicatorTypes.API_KEY
         o.value = get_object_values(cybox_obj.description)
         return o
     elif isinstance(cybox_obj, DomainName):
-        o.object_type = "URI - Domain Name"
+        o.object_type = IndicatorTypes.DOMAIN
         o.value = get_object_values(cybox_obj.value)
-        return o
-    elif isinstance(cybox_obj, EmailMessage):
-        o.object_type = "Email Message"
-        o.value = [cybox_obj.raw_body]
-        return o
-    elif isinstance(cybox_obj, GUIDialogbox):
-        o.object_type = "GUI Dialogbox"
-        o.value = get_object_values(cybox_obj.box_text)
-        return o
-    elif isinstance(cybox_obj, GUIWindow):
-        o.object_type = "GUI Window"
-        o.value = get_object_values(cybox_obj.window_display_name)
-        return o
-    elif isinstance(cybox_obj, Library):
-        o.object_type = "Library"
-        o.name = str(cybox_obj.type)
-        o.value = get_object_values(cybox_obj.name)
-        return o
-    elif isinstance(cybox_obj, Memory):
-        o.object_type = "Memory"
-        o.value = get_object_values(cybox_obj.memory_source)
         return o
     elif isinstance(cybox_obj, Mutex):
-        o.object_type = "Mutex"
+        o.object_type = IndicatorTypes.MUTEX
         o.value = get_object_values(cybox_obj.name)
         return o
-    elif isinstance(cybox_obj, NetworkConnection):
-        o.object_type = "Network Connection"
-        o.value = get_object_values(cybox_obj.layer7_protocol)
-        return o
-    elif isinstance(cybox_obj, Pipe):
-        o.object_type = "Pipe"
-        o.value = get_object_values(cybox_obj.name)
-        return o
-    elif isinstance(cybox_obj, Port):
-        o.object_type = "Port"
-        o.value = get_object_values(cybox_obj.port_value)
-        return o
+    # Unless there is a way to know this is source or destination, this doesn't
+    # help :(
+    #elif isinstance(cybox_obj, Port):
+    #    o.object_type = "Port"
+    #    o.value = get_object_values(cybox_obj.port_value)
+    #    return o
     elif isinstance(cybox_obj, Process):
-        o.object_type = "Process"
+        o.object_type = IndicatorTypes.PROCESS_NAME
         o.value = get_object_values(cybox_obj.name)
-        return o
-    elif isinstance(cybox_obj, System):
-        o.object_type = "System"
-        o.value = get_object_values(cybox_obj.hostname)
         return o
     elif isinstance(cybox_obj, URI):
-        o.object_type = "URI - URL"
-        o.name = cybox_obj.type_
+        o.object_type = IndicatorTypes.URI
         o.value = get_object_values(cybox_obj.value)
         return o
-    elif isinstance(cybox_obj, UserAccount):
-        o.object_type = "User Account"
-        o.value = get_object_values(cybox_obj.username)
-        return o
-    elif isinstance(cybox_obj, Volume):
-        o.object_type = "Volume"
-        o.value = get_object_values(cybox_obj.name)
-        return o
-    elif isinstance(cybox_obj, WinDriver):
-        o.object_type = "Win Driver"
-        o.value = get_object_values(cybox_obj.driver_name)
-        return o
-    elif isinstance(cybox_obj, WinEventLog):
-        o.object_type = "Win Event Log"
-        o.value = get_object_values(cybox_obj.log)
-        return o
-    elif isinstance(cybox_obj, WinEvent):
-        o.object_type = "Win Event"
-        o.value = get_object_values(cybox_obj.name)
-        return o
-    elif isinstance(cybox_obj, WinHandle):
-        o.object_type = "Win Handle"
-        o.name = str(cybox_obj.type_)
-        o.value = get_object_values(cybox_obj.object_address)
-        return o
-    elif isinstance(cybox_obj, WinKernelHook):
-        o.object_type = "Win Kernel Hook"
-        o.value = get_object_values(cybox_obj.description)
-        return o
-    elif isinstance(cybox_obj, WinMailslot):
-        o.object_type = "Win Mailslot"
-        o.value = get_object_values(cybox_obj.name)
-        return o
-    elif isinstance(cybox_obj, WinNetworkShare):
-        o.object_type = "Win Network Share"
-        o.value = get_object_values(cybox_obj.local_path)
-        return o
-    elif isinstance(cybox_obj, WinProcess):
-        o.object_type = "Win Process"
-        o.value = get_object_values(cybox_obj.window_title)
-        return o
     elif isinstance(cybox_obj, WinRegistryKey):
-        o.object_type = "Win Registry Key"
+        o.object_type = IndicatorTypes.REGISTRY_KEY
         o.value = get_object_values(cybox_obj.key)
-        return o
-    elif isinstance(cybox_obj, WinService):
-        o.object_type = "Win Service"
-        o.value = get_object_values(cybox_obj.service_name)
-        return o
-    elif isinstance(cybox_obj, WinSystem):
-        o.object_type = "Win System"
-        o.value = get_object_values(cybox_obj.product_name)
-        return o
-    elif isinstance(cybox_obj, WinTask):
-        o.object_type = "Win Task"
-        o.value = get_object_values(cybox_obj.name)
-        return o
-    elif isinstance(cybox_obj, WinUser):
-        o.object_type = "Win User Account"
-        o.value = get_object_values(cybox_obj.security_id)
-        return o
-    elif isinstance(cybox_obj, WinVolume):
-        o.object_type = "Win Volume"
-        o.value = get_object_values(cybox_obj.drive_letter)
-        return o
-    elif isinstance(cybox_obj, X509Certificate):
-        o.object_type = "X509 Certificate"
-        o.value = get_object_values(cybox_obj.raw_certificate)
         return o
     raise UnsupportedCRITsObjectTypeError(cybox_obj)

--- a/taxii_service/object_mapper.py
+++ b/taxii_service/object_mapper.py
@@ -1,0 +1,519 @@
+from crits.core.crits_mongoengine import EmbeddedObject
+
+from cybox.common import String, PositiveInteger, StructuredText
+from cybox.common.object_properties import CustomProperties, Property
+
+from cybox.objects.account_object import Account
+from cybox.objects.address_object import Address
+from cybox.objects.api_object import API
+from cybox.objects.artifact_object import Artifact
+from cybox.objects.code_object import Code
+from cybox.objects.custom_object import Custom
+from cybox.objects.disk_object import Disk
+from cybox.objects.disk_partition_object import DiskPartition
+from cybox.objects.domain_name_object import DomainName
+from cybox.objects.dns_query_object import DNSQuery, DNSQuestion, DNSRecord
+from cybox.objects.email_message_object import EmailMessage
+from cybox.objects.gui_dialogbox_object import GUIDialogbox
+from cybox.objects.gui_window_object import GUIWindow
+from cybox.objects.http_session_object import HTTPRequestHeaderFields
+from cybox.objects.library_object import Library
+from cybox.objects.memory_object import Memory
+from cybox.objects.mutex_object import Mutex
+from cybox.objects.network_connection_object import NetworkConnection
+from cybox.objects.pipe_object import Pipe
+from cybox.objects.port_object import Port
+from cybox.objects.process_object import Process
+from cybox.objects.system_object import System
+from cybox.objects.uri_object import URI
+from cybox.objects.user_account_object import UserAccount
+from cybox.objects.volume_object import Volume
+from cybox.objects.win_driver_object import WinDriver
+from cybox.objects.win_event_object import WinEvent
+from cybox.objects.win_event_log_object import WinEventLog
+from cybox.objects.win_handle_object import WinHandle
+from cybox.objects.win_kernel_hook_object import WinKernelHook
+from cybox.objects.win_mailslot_object import WinMailslot
+from cybox.objects.win_network_share_object import WinNetworkShare
+from cybox.objects.win_process_object import WinProcess
+from cybox.objects.win_registry_key_object import WinRegistryKey
+from cybox.objects.win_service_object import WinService
+from cybox.objects.win_system_object import WinSystem
+from cybox.objects.win_task_object import WinTask
+from cybox.objects.win_user_object import WinUser
+from cybox.objects.win_volume_object import WinVolume
+from cybox.objects.x509_certificate_object import X509Certificate
+
+class UnsupportedCybOXObjectTypeError(Exception):
+    """
+    Exception to return if we've detected an unknown CybOX object type.
+    """
+
+    def __init__(self, type_, name, **kwargs):
+        self.message = ('"%s - %s" is currently unsupported'
+                   " for output to CybOX." % (type_, name))
+
+    def __str__(self):
+        return repr(self.message)
+
+class UnsupportedCRITsObjectTypeError(Exception):
+    """
+    Exception to return if we've detected an unknown CRITs object type.
+    """
+
+    def __init__(self, cybox_obj, **kwargs):
+        self.message = ('"%s" is currently unsupported'
+                   " for input into CRITs." % (type(cybox_obj).__name__))
+
+    def __str__(self):
+        return repr(self.message)
+
+def get_object_values(obj):
+    try:
+        return obj.values
+    except:
+        return [obj.value]
+
+def make_cybox_object(type_, name=None, value=None):
+    """
+    Converts type_, name, and value to a CybOX object instance.
+
+    :param type_: The object type.
+    :type type_: str
+    :param name: The object name.
+    :type name: str
+    :param value: The object value.
+    :type value: str
+    :returns: CybOX object
+    """
+
+    if type_ == "Account":
+        acct = Account()
+        acct.description = value
+        return acct
+    elif type_ == "Address":
+        return Address(category=name, address_value=value)
+    elif type_ == "Email Message":
+        e = EmailMessage()
+        e.raw_body = value
+        return e
+    elif type_ == "API":
+        api = API()
+        api.description = value
+        return api
+    elif type_ == "Artifact":
+        if name == "Data Region":
+            atype = Artifact.TYPE_GENERIC
+        elif name == 'FileSystem Fragment':
+            atype = Artifact.TYPE_FILE_SYSTEM
+        elif name == 'Memory Region':
+            atype = Artifact.TYPE_MEMORY
+        else:
+            raise UnsupportedCybOXObjectTypeError(type_, name)
+        return Artifact(value, atype)
+    elif type_ == "Code":
+        obj = Code()
+        obj.code_segment = value
+        obj.type = name
+        return obj
+    elif type_ == "Disk":
+        disk = Disk()
+        disk.disk_name = type_
+        disk.type = name
+        return disk
+    elif type_ == "Disk Partition":
+        disk = DiskPartition()
+        disk.device_name = type_
+        disk.type = name
+        return disk
+    elif type_ == "DNS Query":
+        r = URI()
+        r.value = value
+        dq = DNSQuestion()
+        dq.qname = r
+        d = DNSQuery()
+        d.question = dq
+        return d
+    elif type_ == "DNS Record":
+        # DNS Record indicators in CRITs are just a free form text box, there
+        # is no good way to map them into the attributes of a DNSRecord cybox
+        # object. So just stuff it in the description until someone tells me
+        # otherwise.
+        d = StructuredText(value=value)
+        dr = DNSRecord()
+        dr.description = d
+        return dr
+    elif type_ == "GUI Dialogbox":
+        obj = GUIDialogbox()
+        obj.box_text = value
+        return obj
+    elif type_ == "GUI Window":
+        obj = GUIWindow()
+        obj.window_display_name = value
+        return obj
+    elif type_ == "HTTP Request Header Fields" and name and name == "User-Agent":
+        # TODO/NOTE: HTTPRequestHeaderFields has a ton of fields for info.
+        #    we should revisit this as UI is reworked or CybOX is improved.
+        obj = HTTPRequestHeaderFields()
+        obj.user_agent = value
+        return obj
+    elif type_ == "Library":
+        obj = Library()
+        obj.name = value
+        obj.type = name
+        return obj
+    elif type_ == "Memory":
+        obj = Memory()
+        obj.memory_source = value
+        return obj
+    elif type_ == "Mutex":
+        m = Mutex()
+        m.named = True
+        m.name = String(value)
+        return m
+    elif type_ == "Network Connection":
+        obj = NetworkConnection()
+        obj.layer7_protocol = value
+        return obj
+    elif type_ == "Pipe":
+        p = Pipe()
+        p.named = True
+        p.name = String(value)
+        return p
+    elif type_ == "Port":
+        p = Port()
+        try:
+            p.port_value = PositiveInteger(value)
+        except ValueError: # XXX: Raise a better exception...
+            raise UnsupportedCybOXObjectTypeError(type_, name)
+        return p
+    elif type_ == "Process":
+        p = Process()
+        p.name = String(value)
+        return p
+    elif type_ == "String":
+        c = Custom()
+        c.custom_name = "crits:String"
+        c.description = ("This is a generic string used as the value of an "
+                         "Indicator or Object within CRITs.")
+        c.custom_properties = CustomProperties()
+
+        p1 = Property()
+        p1.name = "value"
+        p1.description = "Generic String"
+        p1.value = value
+        c.custom_properties.append(p1)
+        return c
+    elif type_ == "System":
+        s = System()
+        s.hostname = String(value)
+        return s
+    elif type_ == "URI":
+        r = URI()
+        r.type_ = name
+        r.value = value
+        return r
+    elif type_ == "User Account":
+        obj = UserAccount()
+        obj.username = value
+        return obj
+    elif type_ == "Volume":
+        obj = Volume()
+        obj.name = value
+        return obj
+    elif type_ == "Win Driver":
+        w = WinDriver()
+        w.driver_name = String(value)
+        return w
+    elif type_ == "Win Event Log":
+        obj = WinEventLog()
+        obj.log = value
+        return obj
+    elif type_ == "Win Event":
+        w = WinEvent()
+        w.name = String(value)
+        return w
+    elif type_ == "Win Handle":
+        obj = WinHandle()
+        obj.type_ = name
+        obj.object_address = value
+        return obj
+    elif type_ == "Win Kernel Hook":
+        obj = WinKernelHook()
+        obj.description = value
+        return obj
+    elif type_ == "Win Mailslot":
+        obj = WinMailslot()
+        obj.name = value
+        return obj
+    elif type_ == "Win Network Share":
+        obj = WinNetworkShare()
+        obj.local_path = value
+        return obj
+    elif type_ == "Win Process":
+        obj = WinProcess()
+        obj.window_title = value
+        return obj
+    elif type_ == "Win Registry Key":
+        obj = WinRegistryKey()
+        obj.key = value
+        return obj
+    elif type_ == "Win Service":
+        obj = WinService()
+        obj.service_name = value
+        return obj
+    elif type_ == "Win System":
+        obj = WinSystem()
+        obj.product_name = value
+        return obj
+    elif type_ == "Win Task":
+        obj = WinTask()
+        obj.name = value
+        return obj
+    elif type_ == "Win User Account":
+        obj = WinUser()
+        obj.security_id = value
+        return obj
+    elif type_ == "Win Volume":
+        obj = WinVolume()
+        obj.drive_letter = value
+        return obj
+    elif type_ == "X509 Certificate":
+        obj = X509Certificate()
+        obj.raw_certificate = value
+        return obj
+    """
+    The following are types that are listed in the 'Indicator Type' box of
+    the 'New Indicator' dialog in CRITs. These types, unlike those handled
+    above, cannot be written to or read from CybOX at this point.
+
+    The reason for the type being omitted is written as a comment inline.
+    This can (and should) be revisited as new versions of CybOX are released.
+    NOTE: You will have to update the corresponding make_crits_object function
+    with handling for the reverse direction.
+
+    In the mean time, these types will raise unsupported errors.
+    """
+    #elif type_ == "Device": # No CybOX API
+    #elif type_ == "DNS Cache": # No CybOX API
+    #elif type_ == "GUI": # revisit when CRITs supports width & height specification
+    #elif type_ == "HTTP Session": # No good mapping between CybOX/CRITs
+    #elif type_ == "Linux Package": # No CybOX API
+    #elif type_ == "Network Packet": # No good mapping between CybOX/CRITs
+    #elif type_ == "Network Route Entry": # No CybOX API
+    #elif type_ == "Network Route": # No CybOX API
+    #elif type_ == "Network Subnet": # No CybOX API
+    #elif type_ == "Semaphore": # No CybOX API
+    #elif type_ == "Socket": # No good mapping between CybOX/CRITs
+    #elif type_ == "UNIX File": # No CybOX API
+    #elif type_ == "UNIX Network Route Entry": # No CybOX API
+    #elif type_ == "UNIX Pipe": # No CybOX API
+    #elif type_ == "UNIX Process": # No CybOX API
+    #elif type_ == "UNIX User Account": # No CybOX API
+    #elif type_ == "UNIX Volume": # No CybOX API
+    #elif type_ == "User Session": # No CybOX API
+    #elif type_ == "Whois": # No good mapping between CybOX/CRITs
+    #elif type_ == "Win Computer Account": # No CybOX API
+    #elif type_ == "Win Critical Section": # No CybOX API
+    #elif type_ == "Win Executable File": # No good mapping between CybOX/CRITs
+    #elif type_ == "Win File": # No good mapping between CybOX/CRITs
+    #elif type_ == "Win Kernel": # No CybOX API
+    #elif type_ == "Win Mutex": # No good mapping between CybOX/CRITs
+    #elif type_ == "Win Network Route Entry": # No CybOX API
+    #elif type_ == "Win Pipe": # No good mapping between CybOX/CRITs
+    #elif type_ == "Win Prefetch": # No CybOX API
+    #elif type_ == "Win Semaphore": # No CybOX API
+    #elif type_ == "Win System Restore": # No CybOX API
+    #elif type_ == "Win Thread": # No good mapping between CybOX/CRITs
+    #elif type_ == "Win Waitable Timer": # No CybOX API
+    raise UnsupportedCybOXObjectTypeError(type_, name)
+
+def make_crits_object(cybox_obj):
+    """
+    Converts a CybOX object instance to a CRITs EmbeddedObject instance.
+
+    :param cybox_obj: The CybOX object.
+    :type cybox_obj: CybOX object.
+    :returns: :class:`crits.core.crits_mongoengine.EmbeddedObject`
+    """
+
+    o = EmbeddedObject()
+    o.datatype = "string"
+    if isinstance(cybox_obj, Account):
+        o.object_type = "Account"
+        o.value = get_object_values(cybox_obj.description)
+        return o
+    elif isinstance(cybox_obj, Address):
+        o.object_type = "Address"
+        o.name = str(cybox_obj.category)
+        o.value = get_object_values(cybox_obj.address_value)
+        return o
+    elif isinstance(cybox_obj, API):
+        o.object_type = "API"
+        o.value = get_object_values(cybox_obj.description)
+        return o
+    elif isinstance(cybox_obj, Artifact):
+        o.object_type = "Artifact"
+        o.value = [cybox_obj.data]
+        if cybox_obj.type_ == Artifact.TYPE_GENERIC:
+            o.name = "Data Region"
+            return o
+        elif cybox_obj.type_ == Artifact.TYPE_FILE_SYSTEM:
+            o.name = "FileSystem Fragment"
+            return o
+        elif cybox_obj.type_ == Artifact.TYPE_MEMORY:
+            o.name = "Memory Region"
+            return o
+    elif isinstance(cybox_obj, Code):
+        o.object_type = "Code"
+        o.name = str(cybox_obj.type)
+        o.value = get_object_values(cybox_obj.code_segment)
+        return o
+    elif isinstance(cybox_obj, Custom):
+        if cybox_obj.custom_name == "crits:String":
+            if cybox_obj.custom_properties[0].name == "value":
+                o.object_type = "String"
+                o.value = [cybox_obj.custom_properties[0].value]
+                return o
+    elif isinstance(cybox_obj, Disk):
+        o.object_type = "Disk"
+        o.name = str(cybox_obj.type)
+        o.value = get_object_values(cybox_obj.disk_name)
+        return o
+    elif isinstance(cybox_obj, DiskPartition):
+        o.object_type = "Disk Partition"
+        o.name = str(cybox_obj.type)
+        o.value = get_object_values(cybox_obj.device_name)
+        return o
+    elif isinstance(cybox_obj, DNSQuery):
+        o.object_type = "DNS Query"
+        o.value = get_object_values(cybox_obj.question.qname)
+        return o
+    elif isinstance(cybox_obj, DNSRecord):
+        o.object_type = "DNS Record"
+        o.value = get_object_values(cybox_obj.description)
+        return o
+    elif isinstance(cybox_obj, DomainName):
+        o.object_type = "URI - Domain Name"
+        o.value = get_object_values(cybox_obj.value)
+        return o
+    elif isinstance(cybox_obj, EmailMessage):
+        o.object_type = "Email Message"
+        o.value = [cybox_obj.raw_body]
+        return o
+    elif isinstance(cybox_obj, GUIDialogbox):
+        o.object_type = "GUI Dialogbox"
+        o.value = get_object_values(cybox_obj.box_text)
+        return o
+    elif isinstance(cybox_obj, GUIWindow):
+        o.object_type = "GUI Window"
+        o.value = get_object_values(cybox_obj.window_display_name)
+        return o
+    elif isinstance(cybox_obj, Library):
+        o.object_type = "Library"
+        o.name = str(cybox_obj.type)
+        o.value = get_object_values(cybox_obj.name)
+        return o
+    elif isinstance(cybox_obj, Memory):
+        o.object_type = "Memory"
+        o.value = get_object_values(cybox_obj.memory_source)
+        return o
+    elif isinstance(cybox_obj, Mutex):
+        o.object_type = "Mutex"
+        o.value = get_object_values(cybox_obj.name)
+        return o
+    elif isinstance(cybox_obj, NetworkConnection):
+        o.object_type = "Network Connection"
+        o.value = get_object_values(cybox_obj.layer7_protocol)
+        return o
+    elif isinstance(cybox_obj, Pipe):
+        o.object_type = "Pipe"
+        o.value = get_object_values(cybox_obj.name)
+        return o
+    elif isinstance(cybox_obj, Port):
+        o.object_type = "Port"
+        o.value = get_object_values(cybox_obj.port_value)
+        return o
+    elif isinstance(cybox_obj, Process):
+        o.object_type = "Process"
+        o.value = get_object_values(cybox_obj.name)
+        return o
+    elif isinstance(cybox_obj, System):
+        o.object_type = "System"
+        o.value = get_object_values(cybox_obj.hostname)
+        return o
+    elif isinstance(cybox_obj, URI):
+        o.object_type = "URI - URL"
+        o.name = cybox_obj.type_
+        o.value = get_object_values(cybox_obj.value)
+        return o
+    elif isinstance(cybox_obj, UserAccount):
+        o.object_type = "User Account"
+        o.value = get_object_values(cybox_obj.username)
+        return o
+    elif isinstance(cybox_obj, Volume):
+        o.object_type = "Volume"
+        o.value = get_object_values(cybox_obj.name)
+        return o
+    elif isinstance(cybox_obj, WinDriver):
+        o.object_type = "Win Driver"
+        o.value = get_object_values(cybox_obj.driver_name)
+        return o
+    elif isinstance(cybox_obj, WinEventLog):
+        o.object_type = "Win Event Log"
+        o.value = get_object_values(cybox_obj.log)
+        return o
+    elif isinstance(cybox_obj, WinEvent):
+        o.object_type = "Win Event"
+        o.value = get_object_values(cybox_obj.name)
+        return o
+    elif isinstance(cybox_obj, WinHandle):
+        o.object_type = "Win Handle"
+        o.name = str(cybox_obj.type_)
+        o.value = get_object_values(cybox_obj.object_address)
+        return o
+    elif isinstance(cybox_obj, WinKernelHook):
+        o.object_type = "Win Kernel Hook"
+        o.value = get_object_values(cybox_obj.description)
+        return o
+    elif isinstance(cybox_obj, WinMailslot):
+        o.object_type = "Win Mailslot"
+        o.value = get_object_values(cybox_obj.name)
+        return o
+    elif isinstance(cybox_obj, WinNetworkShare):
+        o.object_type = "Win Network Share"
+        o.value = get_object_values(cybox_obj.local_path)
+        return o
+    elif isinstance(cybox_obj, WinProcess):
+        o.object_type = "Win Process"
+        o.value = get_object_values(cybox_obj.window_title)
+        return o
+    elif isinstance(cybox_obj, WinRegistryKey):
+        o.object_type = "Win Registry Key"
+        o.value = get_object_values(cybox_obj.key)
+        return o
+    elif isinstance(cybox_obj, WinService):
+        o.object_type = "Win Service"
+        o.value = get_object_values(cybox_obj.service_name)
+        return o
+    elif isinstance(cybox_obj, WinSystem):
+        o.object_type = "Win System"
+        o.value = get_object_values(cybox_obj.product_name)
+        return o
+    elif isinstance(cybox_obj, WinTask):
+        o.object_type = "Win Task"
+        o.value = get_object_values(cybox_obj.name)
+        return o
+    elif isinstance(cybox_obj, WinUser):
+        o.object_type = "Win User Account"
+        o.value = get_object_values(cybox_obj.security_id)
+        return o
+    elif isinstance(cybox_obj, WinVolume):
+        o.object_type = "Win Volume"
+        o.value = get_object_values(cybox_obj.drive_letter)
+        return o
+    elif isinstance(cybox_obj, X509Certificate):
+        o.object_type = "X509 Certificate"
+        o.value = get_object_values(cybox_obj.raw_certificate)
+        return o
+    raise UnsupportedCRITsObjectTypeError(cybox_obj)

--- a/taxii_service/object_mapper.py
+++ b/taxii_service/object_mapper.py
@@ -243,7 +243,7 @@ def make_cybox_object(type_, value=None):
         return p
     elif type_ == IndicatorTypes.URI:
         r = URI()
-        r.type_ = name
+        r.type_ = 'URL'
         r.value = value
         return r
     elif type_ in (IndicatorTypes.REGISTRY_KEY,

--- a/taxii_service/parsers.py
+++ b/taxii_service/parsers.py
@@ -1,0 +1,516 @@
+import datetime
+
+from StringIO import StringIO
+
+from .object_mapper import make_crits_object
+
+from crits.actors.actor import Actor
+from crits.actors.handlers import add_new_actor, update_actor_tags
+from crits.certificates.handlers import handle_cert_file
+from crits.domains.handlers import upsert_domain
+from crits.emails.handlers import handle_email_fields
+from crits.events.handlers import add_new_event
+from crits.indicators.indicator import Indicator
+from crits.indicators.handlers import handle_indicator_ind
+from crits.ips.handlers import ip_add_update
+from crits.pcaps.handlers import handle_pcap_file
+from crits.raw_data.handlers import handle_raw_data_file
+from crits.samples.handlers import handle_file
+from crits.core.crits_mongoengine import EmbeddedSource
+from crits.core.handlers import does_source_exist
+
+from cybox.objects.artifact_object import Artifact
+from cybox.objects.address_object import Address
+from cybox.objects.domain_name_object import DomainName
+from cybox.objects.email_message_object import EmailMessage
+from cybox.objects.file_object import File
+
+from stix.common import StructuredText
+from stix.core import STIXPackage, STIXHeader
+
+class STIXParserException(Exception):
+    """
+    General exception for STIX Parsing.
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+class STIXParser():
+    """
+    STIX Parser class.
+    """
+
+    def __init__(self, data, analyst, method):
+        """
+        Instantiation of the STIXParser can take the data to parse, the analyst
+        doing the parsing, and the method of data aquisition.
+
+        :param data: The data to parse.
+        :type data: str
+        :param analyst: The analyst parsing the document.
+        :type analyst: str
+        :param method: The method of acquiring this data.
+        :type method: str
+        """
+
+        self.data = data
+
+        self.package = None
+
+        self.source = EmbeddedSource() # source.name comes from the stix header.
+        self.source_instance = EmbeddedSource.SourceInstance()
+        # The reference attribute and appending it to the source is
+        # done after the TAXII message ID is determined.
+        self.source_instance.analyst = analyst
+        self.source_instance.method = method
+        self.information_source = None
+
+        self.event = None # the Event TLO
+        self.event_rels = {} # track relationships to the event
+        self.relationships = [] # track other relationships that need forming
+        self.imported = {} # track items that are imported
+        self.failed = [] # track STIX/CybOX items that failed import
+        self.saved_artifacts = {}
+
+    def parse_stix(self, reference='', make_event=False, source=''):
+        """
+        Parse the document.
+
+        :param reference: The reference to the data.
+        :type reference: str
+        :param make_event: Whether or not to create an Event for this document.
+        :type make_event: bool
+        :param source: The source of this document.
+        :type source: str
+        :raises: :class:`taxii_service.parsers.STIXParserException`
+
+        Until we have a way to map source strings in a STIX document to
+        a source in CRITs, we are being safe and using the source provided
+        as the true source.
+        """
+
+        f = StringIO(self.data)
+        self.package = STIXPackage.from_xml(f)
+        f.close()
+        if not self.package:
+            raise STIXParserException("STIX package failure")
+
+        stix_header = self.package.stix_header
+        if stix_header and stix_header.information_source and stix_header.information_source.identity:
+            self.information_source = stix_header.information_source.identity.name
+            if self.information_source:
+                info_src = "STIX Source: %s" % self.information_source
+                if not reference:
+                    reference = ''
+                else:
+                    reference += ", "
+                reference += info_src
+        if does_source_exist(source):
+            self.source.name = source
+        elif does_source_exist(self.information_source):
+            self.source.name = self.information_source
+        else:
+            raise STIXParserException("No source to attribute data to.")
+
+        self.source_instance.reference = reference
+        self.source.instances.append(self.source_instance)
+
+        if make_event:
+            title = "STIX Document %s" % self.package.id_
+            event_type = "Collective Threat Intelligence"
+            date = datetime.datetime.now()
+            description = str(date)
+            header = self.package.stix_header
+            if isinstance(header, STIXHeader):
+                if header.title:
+                    title = header.title
+                if hasattr(header, 'package_intents'):
+                    event_type = str(header.package_intents[0])
+                if header.description:
+                    description = header.description
+                    if isinstance(description, StructuredText):
+                        try:
+                            description = description.to_dict()
+                        except:
+                            pass
+            res = add_new_event(title,
+                                description,
+                                event_type,
+                                self.source.name,
+                                self.source_instance.method,
+                                self.source_instance.reference,
+                                date,
+                                self.source_instance.analyst)
+            if res['success']:
+                self.event = res['object']
+                self.imported[self.package.id_] = ('Event', res['object'])
+
+                # Get relationships to the Event
+                if self.package.incidents:
+                    incdnts = self.package.incidents
+                    for rel in getattr(incdnts[0], 'related_indicators', ()):
+                        self.event_rels[rel.item.idref] = (rel.relationship.value,
+                                                           rel.confidence.value.value)
+            else:
+                self.failed.append((res['message'],
+                                    "STIX Event",
+                                    ""))
+
+        if self.package.indicators:
+            self.parse_indicators(self.package.indicators)
+
+        if self.package.observables and self.package.observables.observables:
+            self.parse_observables(self.package.observables.observables)
+
+        if self.package.threat_actors:
+            self.parse_threat_actors(self.package.threat_actors)
+
+    def parse_threat_actors(self, threat_actors):
+        """
+        Parse list of Threat Actors.
+
+        :param threat_actors: List of STIX ThreatActors.
+        :type threat_actors: List of STIX ThreatActors.
+        """
+        from stix.threat_actor import ThreatActor
+        analyst = self.source_instance.analyst
+        for threat_actor in threat_actors: # for each STIX ThreatActor
+            try: # create CRITs Actor from ThreatActor
+                if isinstance(threat_actor, ThreatActor):
+                    name = str(threat_actor.title)
+                    description = str(threat_actor.description)
+                    res = add_new_actor(name=name,
+                                        description=description,
+                                        source=[self.source],
+                                        analyst=analyst)
+                    if res['success']:
+                        sl = ml = tl = il = []
+                        for s in threat_actor.sophistications:
+                            sl.append(str(s.value))
+                        update_actor_tags(res['id'],
+                                            'ActorSophistication',
+                                            sl,
+                                            analyst)
+                        for m in threat_actor.motivations:
+                            ml.append(str(m.value))
+                        update_actor_tags(res['id'],
+                                            'ActorMotivation',
+                                            ml,
+                                            analyst)
+                        for t in threat_actor.types:
+                            tl.append(str(t.value))
+                        update_actor_tags(res['id'],
+                                            'ActorThreatType',
+                                            tl,
+                                            analyst)
+                        for i in threat_actor.intended_effects:
+                            il.append(str(i.value))
+                        update_actor_tags(res['id'],
+                                            'ActorIntendedEffect',
+                                            il,
+                                            analyst)
+                        obj = Actor.objects(id=res['id']).first()
+                        self.imported[threat_actor.id_] = (Actor._meta['crits_type'],
+                                                           obj)
+                    else:
+                        self.failed.append((res['message'],
+                                            type(threat_actor).__name__,
+                                            "")) # note for display in UI
+            except Exception, e:
+                self.failed.append((e.message, type(threat_actor).__name__,
+                                    "")) # note for display in UI
+
+    def parse_indicators(self, indicators):
+        """
+        Parse list of indicators.
+
+        :param indicators: List of STIX indicators.
+        :type indicators: List of STIX indicators.
+        """
+
+        analyst = self.source_instance.analyst
+        for indicator in indicators: # for each STIX indicator
+
+            # store relationships
+            for rel in getattr(indicator, 'related_indicators', ()):
+                self.relationships.append((indicator.id_,
+                                           rel.relationship.value,
+                                           rel.item.idref,
+                                           rel.confidence.value.value))
+
+            # handled indicator-wrapped observable
+            if getattr(indicator, 'title', ""):
+                if "Top-Level Object" in indicator.title:
+                    self.parse_observables(indicator.observables)
+                    result = self.imported.pop(indicator.observables[0].id_, None)
+                    if result:
+                        self.imported[indicator.id_] = result
+                    continue
+
+            for observable in indicator.observables: # get each observable from indicator (expecting only 1)
+                try: # create CRITs Indicator from observable
+                    item = observable.object_.properties
+                    obj = make_crits_object(item)
+                    if obj.name and obj.name != obj.object_type:
+                        ind_type = "%s - %s" % (obj.object_type, obj.name)
+                    else:
+                        ind_type = obj.object_type
+                    for value in obj.value:
+                        if value and ind_type:
+                            res = handle_indicator_ind(value.strip(),
+                                                       self.source,
+                                                       ind_type,
+                                                       analyst,
+                                                       add_domain=True,
+                                                       add_relationship=True)
+                            if res['success']:
+                                self.imported[indicator.id_] = (Indicator._meta['crits_type'],
+                                                                res['object'])
+                            else:
+                                self.failed.append((res['message'],
+                                                    type(item).__name__,
+                                                    item.parent.id_)) # note for display in UI
+                except Exception, e: # probably caused by cybox object we don't handle
+                    self.failed.append((e.message, type(item).__name__, item.parent.id_)) # note for display in UI
+
+    def parse_observables(self, observables):
+        """
+        Parse list of observables in STIX doc.
+
+        :param observables: List of STIX observables.
+        :type observables: List of STIX observables.
+        """
+
+        analyst = self.source_instance.analyst
+        for obs in observables: # for each STIX observable
+            if not obs.object_ or not obs.object_.properties:
+                self.failed.append(("No valid object_properties was found!",
+                                    type(obs).__name__,
+                                    obs.id_)) # note for display in UI
+                continue
+            try: # try to create CRITs object from observable
+                item = obs.object_.properties
+                if isinstance(item, Address):
+                    if item.category in ('cidr', 'ipv4-addr', 'ipv4-net',
+                                         'ipv4-netmask', 'ipv6-addr',
+                                         'ipv6-net', 'ipv6-netmask'):
+                        imp_type = "IP"
+                        for value in item.address_value.values:
+                            ip = str(value).strip()
+                            iptype = "Address - %s" % item.category
+                            res = ip_add_update(ip,
+                                                iptype,
+                                                [self.source],
+                                                analyst=analyst,
+                                                is_add_indicator=True)
+                            self.parse_res(imp_type, obs, res)
+                if isinstance(item, DomainName):
+                    imp_type = "Domain"
+                    for value in item.value.values:
+                        res = upsert_domain(str(value),
+                                            [self.source],
+                                            username=analyst)
+                        self.parse_res(imp_type, obs, res)
+                elif isinstance(item, Artifact):
+                    # Not sure if this is right, and I believe these can be
+                    # encoded in a couple different ways.
+                    imp_type = "RawData"
+                    rawdata = item.data.decode('utf-8')
+                    description = "None"
+                    # TODO: find out proper ways to determine title, datatype,
+                    #       tool_name, tool_version
+                    title = "Artifact for Event: STIX Document %s" % self.package.id_
+                    res = handle_raw_data_file(rawdata,
+                                            self.source.name,
+                                            user=analyst,
+                                            description=description,
+                                            title=title,
+                                            data_type="Text",
+                                            tool_name="STIX",
+                                            tool_version=None,
+                                            method=self.source_instance.method,
+                                            reference=self.source_instance.reference)
+                    self.parse_res(imp_type, obs, res)
+                elif (isinstance(item, File) and
+                      item.custom_properties and
+                      item.custom_properties[0].name == "crits_type" and
+                      item.custom_properties[0]._value == "Certificate"):
+                    imp_type = "Certificate"
+                    description = "None"
+                    filename = str(item.file_name)
+                    data = None
+                    for obj in item.parent.related_objects:
+                        if isinstance(obj.properties, Artifact):
+                            data = obj.properties.data
+                    res = handle_cert_file(filename,
+                                           data,
+                                           self.source,
+                                           user=analyst,
+                                           description=description)
+                    self.parse_res(imp_type, obs, res)
+                elif isinstance(item, File) and self.has_network_artifact(item):
+                    imp_type = "PCAP"
+                    description = "None"
+                    filename = str(item.file_name)
+                    data = None
+                    for obj in item.parent.related_objects:
+                        if (isinstance(obj.properties, Artifact) and
+                            obj.properties.type_ == Artifact.TYPE_NETWORK):
+                            data = obj.properties.data
+                    res = handle_pcap_file(filename,
+                                           data,
+                                           self.source,
+                                           user=analyst,
+                                           description=description)
+                    self.parse_res(imp_type, obs, res)
+                elif isinstance(item, File):
+                    imp_type = "Sample"
+                    filename = str(item.file_name)
+                    md5 = item.md5
+                    data = None
+                    for obj in item.parent.related_objects:
+                        if (isinstance(obj.properties, Artifact) and
+                            obj.properties.type_ == Artifact.TYPE_FILE):
+                            data = obj.properties.data
+                    res = handle_file(filename,
+                                      data,
+                                      self.source,
+                                      user=analyst,
+                                      md5_digest=md5,
+                                      is_return_only_md5=False)
+                    self.parse_res(imp_type, obs, res)
+                elif isinstance(item, EmailMessage):
+                    imp_type = "Email"
+                    data = {}
+                    data['source'] = self.source.name
+                    data['source_method'] = self.source_instance.method
+                    data['source_reference'] = self.source_instance.reference
+                    data['raw_body'] = str(item.raw_body)
+                    data['raw_header'] = str(item.raw_header)
+                    data['helo'] = str(item.email_server)
+                    if item.header:
+                        data['message_id'] = str(item.header.message_id)
+                        data['subject'] = str(item.header.subject)
+                        data['sender'] = str(item.header.sender)
+                        data['reply_to'] = str(item.header.reply_to)
+                        data['x_originating_ip'] = str(item.header.x_originating_ip)
+                        data['x_mailer'] = str(item.header.x_mailer)
+                        data['boundary'] = str(item.header.boundary)
+                        data['from_address'] = str(item.header.from_)
+                        data['date'] = item.header.date.value
+                        if item.header.to:
+                            data['to'] = [str(r) for r in item.header.to.to_list()]
+                    res = handle_email_fields(data,
+                                            analyst,
+                                            "STIX")
+                    # Should check for attachments and add them here.
+                    self.parse_res(imp_type, obs, res)
+                    if res.get('status') and item.attachments:
+                        for attach in item.attachments:
+                            rel_id = attach.to_dict()['object_reference']
+                            self.relationships.append((obs.id_,
+                                                       "Contains",
+                                                       rel_id, "High"))
+                else: # try to parse all other possibilities as Indicator
+                    imp_type = "Indicator"
+                    obj = make_crits_object(item)
+                    if (obj.object_type == 'Address' and
+                        obj.name in ('cidr', 'ipv4-addr', 'ipv4-net',
+                                     'ipv4-netmask', 'ipv6-addr',
+                                     'ipv6-net', 'ipv6-netmask')):
+                        # This was already caught above
+                        continue
+                    else:
+                        if obj.name and obj.name != obj.object_type:
+                            ind_type = "%s - %s" % (obj.object_type, obj.name)
+                        else:
+                            ind_type = obj.object_type
+                        for value in obj.value:
+                            if value and ind_type:
+                                res = handle_indicator_ind(value.strip(),
+                                                        self.source,
+                                                        ind_type,
+                                                        analyst,
+                                                        add_domain=True,
+                                                        add_relationship=True)
+                                self.parse_res(imp_type, obs, res)
+            except Exception, e: # probably caused by cybox object we don't handle
+                self.failed.append((e.message,
+                                    type(item).__name__,
+                                    item.parent.id_)) # note for display in UI
+
+    def parse_res(self, imp_type, obs, res):
+        s = res.get('success', None)
+        if s is None:
+            s = res.get('status', None)
+        if s:
+            self.imported[obs.id_] = (imp_type,
+                                      res['object']) # use class to parse object
+        else:
+            if 'reason' in res:
+                msg = res['reason']
+            elif 'message' in res:
+                msg = res['message']
+            else:
+                msg = "Failed for unknown reason."
+            self.failed.append((msg,
+                                type(obs).__name__,
+                                obs.id_)) # note for display in UI
+
+    def has_network_artifact(self, file_obj):
+        """
+        Determine if the CybOX File object has a related Artifact of
+        'Network' type.
+
+        :param file_obj: A CybOX File object
+        :return: True if the File has a Network Traffic Artifact
+        """
+        if not file_obj or not file_obj.parent or not file_obj.parent.related_objects:
+            return False
+        for obj in file_obj.parent.related_objects: # attempt to find data in cybox
+            if isinstance(obj.properties, Artifact) and obj.properties.type_ == Artifact.TYPE_NETWORK:
+                return True
+        return False
+
+    def relate_objects(self):
+        """
+        If an Incident was included in the STIX package, its
+        related_indicators attribute is used to relate objects to the event.
+        Any objects without an explicit relationship to the event are
+        related using type "Related_To".
+
+        Objects are related to each other using the relationships listed in
+        their related_indicators attribute.
+        """
+        analyst = self.source_instance.analyst
+
+        # relate objects to Event
+        if self.event:
+            evt = self.event
+            for id_ in self.imported:
+                if id_ in self.event_rels:
+                    evt.add_relationship(self.imported[id_][1],
+                                         rel_type=self.event_rels[id_][0],
+                                         rel_confidence=self.event_rels[id_][1],
+                                         analyst=analyst)
+                elif self.imported[id_][0] != 'Event':
+                    evt.add_relationship(self.imported[id_][1],
+                                         rel_type='Related_To',
+                                         rel_confidence='Unknown',
+                                         analyst=analyst)
+            evt.save(username=analyst)
+
+        # relate objects to each other
+        for rel in self.relationships:
+            if rel[0] in self.imported and rel[2] in self.imported:
+                left = self.imported[rel[0]][1]
+                right = self.imported[rel[2]][1]
+                left.add_relationship(right,
+                                      rel_type=rel[1],
+                                      rel_confidence=rel[3],
+                                      analyst=analyst)
+
+        # save objects
+        for id_ in self.imported:
+            self.imported[id_][1].save(username=analyst)

--- a/taxii_service/parsers.py
+++ b/taxii_service/parsers.py
@@ -19,6 +19,11 @@ from crits.samples.handlers import handle_file
 from crits.core.crits_mongoengine import EmbeddedSource
 from crits.core.handlers import does_source_exist
 
+from crits.vocabulary.indicators import (
+    IndicatorAttackTypes,
+    IndicatorThreatTypes
+)
+
 from cybox.objects.artifact_object import Artifact
 from cybox.objects.address_object import Address
 from cybox.objects.domain_name_object import DomainName
@@ -261,6 +266,8 @@ class STIXParser():
                             res = handle_indicator_ind(value.strip(),
                                                        self.source,
                                                        ind_type,
+                                                       IndicatorThreatTypes.UNKNOWN,
+                                                       IndicatorAttackTypes.UNKNOWN,
                                                        analyst,
                                                        add_domain=True,
                                                        add_relationship=True)
@@ -431,6 +438,8 @@ class STIXParser():
                                 res = handle_indicator_ind(value.strip(),
                                                         self.source,
                                                         ind_type,
+                                                        IndicatorThreatTypes.UNKNOWN,
+                                                        IndicatorAttackTypes.UNKNOWN,
                                                         analyst,
                                                         add_domain=True,
                                                         add_relationship=True)

--- a/taxii_service/templates/import_results.html
+++ b/taxii_service/templates/import_results.html
@@ -1,0 +1,45 @@
+<table class="vertical" width="353px">
+    <thead>
+    </thead>
+    <tbody>
+    {% if imported %}
+    <tr>
+        <td colspan="2" style="text-align: center"><b>Imported</b></td>
+    </tr>
+            {% for key, item in imported.items %}
+                <tr>
+                    <td class="key">
+                        {{item.0}}
+                    </td>
+                    <td>
+                        <a href="{% url 'crits.core.views.details' item.0 item.1.id %}">{{item.1.id}}</a>
+                    </td>
+                </tr>
+            {% endfor %}
+    {% else %}
+        <tr>
+            <td colspan="2" style="text-align: center"><b>Nothing Imported</b></td>
+        </tr>
+    {% endif %}
+    {% if failed %}
+    <tr>
+        <td colspan="2" style="text-align: center"><b>Failed</b></td>
+    </tr>
+            {% for item in failed %}
+                <tr>
+                    <td class="key">
+                        {{item.1}}
+                    </td>
+                    <td>
+                        <b>ID: {{item.2}}</b><br/><br/>
+                        {{item.0}}
+                    </td>
+                </tr>
+            {% endfor %}
+    {% else %}
+        <tr>
+            <td colspan="2" style="text-align: center"><b>Nothing Failed</b></td>
+        </tr>
+    {% endif %}
+    </tbody>
+</table>

--- a/taxii_service/templates/new-standards.html
+++ b/taxii_service/templates/new-standards.html
@@ -1,0 +1,11 @@
+{% load url from future %}
+
+<div id="dialog-{{ request.GET.dialog }}" title="Import STIX Document">
+    <form id="form-{{ request.GET.dialog }}" 
+	  action='{% url "taxii_service.views.upload_standards" %}' 
+	  method='POST' enctype="multipart/form-data" target="new-standards-iframe"
+	  item-type="new-standards" submit-action="default">
+    <table class="form">{{ upload_standards.as_table }}</table>
+    <iframe name="new-standards-iframe" class="file-submit-iframe" style="display:none;"></iframe>
+    </form>
+</div>

--- a/taxii_service/templates/taxii_service_indicator_tab.html
+++ b/taxii_service/templates/taxii_service_indicator_tab.html
@@ -1,17 +1,3 @@
-{% if indicator.has_cybox_repr %}
-    {% with type="Indicator" item=indicator %}       
-        {% include "taxii_service_master_tab.html" %}
-    {% endwith %}
-{% else %}
-<div id="taxii_service" width="100%">
-    <h2>This Indicator cannot be sent via TAXII.</h2>
-    <p>CRITs currently has no way to convert this item to standards. <br/>
-	This means one of two things: 
-		<ul>
-			<li>CybOX currently does not have a representation for an indicator of this type</li>
-			<strong>OR</strong>
-			<li>CRITs doesn't have enough information to populate the minimum required
-	information for the appropriate CybOX object.</li>
-    </p>
-</div>
-{% endif%}
+{% with type="Indicator" item=indicator %}
+    {% include "taxii_service_master_tab.html" %}
+{% endwith %}

--- a/taxii_service/templates/taxii_service_nav_items.html
+++ b/taxii_service/templates/taxii_service_nav_items.html
@@ -2,3 +2,14 @@
 <li class='mmenu_item'>
     <a href="{% url 'taxii_service.views.taxii_agent' %}">TAXII Agent</a>
 </li>
+<li class='mmenu_item'>
+    <a href id="new-standards" class="dialogClick" dialog="new-standards" persona="new" title="Import STIX Document">STIX Import</a>
+</li>
+
+<script>
+    $(document).ready(function() {
+        stdDialog("new-standards", {title: "STIX Document"}, {
+            new: { open: file_upload_dialog, submit: defaultSubmit }
+        });
+    });
+</script>

--- a/taxii_service/urls.py
+++ b/taxii_service/urls.py
@@ -1,8 +1,13 @@
 from django.conf.urls import patterns
 
+def register_api(v1_api):
+    from taxii_service.api import StandardsResource
+    v1_api.register(StandardsResource())
+
 urlpatterns = patterns('taxii_service.views',
     (r'^taxii_agent/$', 'taxii_agent'),
     (r'^get_taxii_config_form/(?P<crits_type>\S+)/(?P<crits_id>\S+)/$', 'get_taxii_config_form'),
     (r'^(?P<crits_type>\S+)/(?P<crits_id>\S+)/$', 'execute_taxii_service'),
     (r'^(?P<crits_type>\S+)/(?P<crits_id>\S+)/preview$', 'preview_taxii_service'),
+    (r'^upload/$', 'upload_standards'),
 )

--- a/taxii_service/views.py
+++ b/taxii_service/views.py
@@ -1,10 +1,9 @@
+import logging
 import json
-import tempfile
 
 from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.shortcuts import render_to_response, HttpResponse
-from django.core.servers.basehttp import FileWrapper
 from django.contrib.auth.decorators import user_passes_test
 
 from crits.core.class_mapper import class_from_id
@@ -12,6 +11,8 @@ from crits.core.user_tools import user_can_view_data
 
 from . import handlers
 from . import forms
+
+logger = logging.getLogger(__name__)
 
 @user_passes_test(user_can_view_data)
 def taxii_agent(request):
@@ -105,5 +106,68 @@ def get_taxii_result(request, crits_type, crits_id, preview):
     else: # form doesn't validate
         data = {'success': False, 'reason': "Invalid options provided. Please fix and try again."}
         return HttpResponse(json.dumps(data), mimetype="application/json")
-    
 
+@user_passes_test(user_can_view_data)
+def upload_standards(request):
+    """
+    Upload a standards document.
+
+    :param request: Django request.
+    :type request: :class:`django.http.HttpRequest`
+    :returns: :class:`django.http.HttpResponse`
+    """
+
+    std_form = forms.UploadStandardsForm(request.user, request.POST, request.FILES)
+    response = {
+                   'form': std_form.as_table(),
+                   'success': False,
+                   'message': ""
+                 }
+
+    if request.method != "POST":
+        response['message'] = "Must submit via POST."
+        return render_to_response('file_upload_response.html',
+                                  {'response': json.dumps(response)},
+                                  RequestContext(request))
+
+    if not std_form.is_valid():
+        response['message'] = "Form is invalid."
+        return render_to_response('file_upload_response.html',
+                                  {'response': json.dumps(response)},
+                                  RequestContext(request))
+
+    data = ''
+    for chunk in request.FILES['filedata']:
+        data += chunk
+
+    make_event = std_form.cleaned_data['make_event']
+    source = std_form.cleaned_data['source']
+
+    reference = std_form.cleaned_data['reference']
+
+
+    # XXX: Add reference to form and handle here?
+    status = handlers.import_standards_doc(data, request.user.username, "Upload",
+                                 ref=reference, make_event=make_event, source=source)
+
+    if not status['success']:
+        response['message'] = status['reason']
+        return render_to_response('file_upload_response.html',
+                                  {'response': json.dumps(response)},
+                                  RequestContext(request))
+
+    response['success'] = True
+    response['message'] = render_to_string("import_results.html", {'failed' : status['failed'], 'imported' : status['imported']})
+    return render_to_response('file_upload_response.html',
+                              {'response': json.dumps(response)},
+                              RequestContext(request))
+
+def taxii_service_context(request):
+    context = {}
+    if request.user.is_authenticated():
+        user = request.user.username
+        try:
+            context['upload_standards'] = forms.UploadStandardsForm(user)
+        except Exception, e:
+            logger.warning("Base Context UploadStandardsForm Error: %s" % e)
+    return context


### PR DESCRIPTION
With CybOX and STIX being removed from core, those in the community that wished to leverage their functionality will find it in the TAXII service.

This PR adds the following functionality to the TAXII service:

- `STIX Import` added to the `Services` navigation menu.
- The `Preview` button on the TAXII tab is now the only way to download a TLO in STIX format.
- All of the mapping functions between CybOX/STIX and the CRITs vocabulary live in the TAXII service.
  - The mapping was updated to reflect the new CRITs vocabulary and is a "best-effort" change. If there is interest in deciding what the best mapping between the CRITs vocabulary and CybOX/STIX is, it can be discussed in Issues and PRs. The core developers will most likely not be doing this work as they do not use CybOX/STIX so it will be up to those community members who do use it to help out.
- The Standards API now lives in the TAXII service.

By doing this it means anyone who is looking to improve, enhance, expand upon, fix, etc. the CybOX/STIX support in CRITs can submit PRs to the service and not core. Once it's accepted it can be used right away instead of having to wait for a new CRITs release to come out.

Also, by that same token, it means that if you are looking to get enhanced support for CybOX/STIX, you'll most likely need to write the code and submit a PR. The separation means that people who don't care to use the standards won't be spending any time interfacing with it anymore so it'll be out of their way.

This PR has to be tested using the `remove_cybox_stix` branch in core which has a PR up as well.