### PR TITLE
Use vis.js for relationship_service

### DIFF
--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -220,6 +220,7 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
             }
 
         n['url'] = href
+        n['crits_status'] = obj['status'];
         n['id'] = obj_id
         n['type'] = n['group'] = obj_type
         n['visible'] = True

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -267,7 +267,8 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
                     n = tlo_styles_dict['Campaign']
                     n['label'] = campaign
                     n['url'] = campaign_href
-                    n['type'] = 'Campaign'
+                    n['type'] = n['group'] = 'Campaign'
+                    n['crits_status'] = 'Analyzed'
                     n['id'] = campaign_id
                     nodes.append(n)
                     obj_graph[campaign_id] = (node_position, [obj_id])

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -176,6 +176,9 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
                 value += " (v:%s)" % obj.version
         href = reverse('crits.core.views.details', args=(obj_type, obj_id))
 
+        if len(types) != 0 and obj_type not in types:
+            continue
+
         # For every campaign on this object, make a new node in the list.
         if hasattr(obj, 'campaign'):
             for i, campaign in enumerate(obj.campaign):

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -42,50 +42,50 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
         'Indicator': {
             'shape': 'dot',
             'size': 10,
-            'color': '#00CCFF',
-            'color_border': '#007A99',
-            'color_highlight': '#66E0FF',
-            'color_highlight_border': '#00CCFF'
+            'color': '#B08751',
+            'color_border': '#907050',
+            'color_highlight': '#CCA075',
+            'color_highlight_border': '#B08751'
         },
         'Event': {
             'shape': 'dot',
             'size': 35,
-            'color': '#00FF00',
-            'color_border': '#009900',
-            'color_highlight': '#66FF66',
-            'color_highlight_border': '#00FF00'
+            'color': '#B05151',
+            'color_border': '#904040',
+            'color_highlight': '#D07171',
+            'color_highlight_border': '#B05151'
         },
         'Sample': {
             'shape': 'dot',
             'size': 25,
-            'color': '#FF6666',
-            'color_border': '#993D3D',
-            'color_highlight': '#FFA3A3',
-            'color_highlight_border': '#FF6666'
+            'color': '#8CCBF8',
+            'color_border': '#70AADC',
+            'color_highlight': '#A0D0FF',
+            'color_highlight_border': '#8CCBF8'
         },
         'Email': {
             'shape': 'dot',
             'size': 25,
-            'color': '#CC66FF',
-            'color_border': '#7A3D99',
-            'color_highlight': '#E0A3FF',
-            'color_highlight_border': '#CC66FF'
+            'color': '#FF8989',
+            'color_border': '#CF7070',
+            'color_highlight': '#FFB0B0',
+            'color_highlight_border': '#FF8989'
         },
         'Domain': {
             'shape': 'dot',
             'size': 20,
-            'color': '#FF9933',
-            'color_border': '#995C1F',
-            'color_highlight': '#FFC285',
-            'color_highlight_border': '#FF9933'
+            'color': '#33EB33',
+            'color_border': '#25C025',
+            'color_highlight': '#55FF55',
+            'color_highlight_border': '#33EB33'
         },
         'IP': {
             'shape': 'dot',
             'size': 20,
-            'color': '#FFFF66',
-            'color_border': '#99993D',
-            'color_highlight': '#FFFFA3',
-            'color_highlight_border': '#FFFF66'
+            'color': '#90F70C',
+            'color_border': '#77C80C',
+            'color_highlight': '#B0FF37',
+            'color_highlight_border': '#90F70C'
         }
     }
 

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -244,7 +244,7 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
             continue
 
         # For every campaign on this object, make a new node in the list.
-        if hasattr(obj, 'campaign'):
+        if 'Campaign' in types and hasattr(obj, 'campaign'):
             for i, campaign in enumerate(obj.campaign):
                 name = "%s" % obj.campaign[i].name
                 if name not in campaign_cache:

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -186,10 +186,10 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
         n = {
               'label': '%s' % value,
               'url': href,
-              'color': color,
               'id': obj_id,
               'type': obj_type,
-              'visible': visible
+              'group': obj_type,
+              'shape': 'dot'
             }
 
         nodes.append(n)
@@ -212,9 +212,8 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
             if sid not in obj_graph or (tid + sid) in link_dict:
                 continue
             link = {
-                     'source': obj_graph[sid][0],
-                     'target': tnode,
-                     'weight': 1,
+                     'from': sid,
+                     'to': tid
                    }
             links.append(link)
             link_dict[sid + tid] = True

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -39,6 +39,70 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
     # Define the styles for each of the data types. Absent these, the vis.js library will
     # auto-select sensible defaults
     tlo_styles_dict = {
+        'Actor': {
+            'shape': 'dot',
+            'size': 25,
+            'color': '#900C0C',
+            'color_border': '#700C0C',
+            'color_highlight': '#90FCFC',
+            'color_highlight_border': '#900C0C'
+        },
+        'Backdoor': {
+            'shape': 'dot',
+            'size': 10,
+            'color': '#5A2C75',
+            'color_border': '#3A1C55',
+            'color_highlight': '#7040B0',
+            'color_highlight_border': '#5A2C75'
+        },
+        'Campaign': {
+            'shape': 'dot',
+            'size': 40,
+            'color': '#FF3737',
+            'color_border': '#D72020',
+            'color_highlight': '#FF6868',
+            'color_highlight_border': '#FF3737'
+        },
+        'Certificate': {
+            'shape': 'dot',
+            'size': 10,
+            'color': '#FFA837',
+            'color_border': '#D08020',
+            'color_highlight': '#FFC060',
+            'color_highlight_border': '#FFA837'
+        },
+        'Exploit': {
+            'shape': 'dot',
+            'size': 10,
+            'color': '#8CA336',
+            'color_border': '#709020',
+            'color_highlight': '#A8CC60',
+            'color_highlight_border': '#8CA336'
+        },
+        'PCAP': {
+            'shape': 'dot',
+            'size': 10,
+            'color': '#FFCC89',
+            'color_border': '#D0A860',
+            'color_highlight': '#FFE0B0',
+            'color_highlight_border': '#FFCC89'
+        },
+        'Raw Data': {
+            'shape': 'dot',
+            'size': 10,
+            'color': '#4A7797',
+            'color_border': '#306080',
+            'color_highlight': '#6090B8',
+            'color_highlight_border': '#4A7797'
+        },
+        'Target': {
+            'shape': 'dot',
+            'size': 10,
+            'color': '#4AA24A',
+            'color_border': '#308030',
+            'color_highlight': '#60C860',
+            'color_highlight_border': '#4AA24A'
+        },
         'Indicator': {
             'shape': 'dot',
             'size': 10,

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -268,6 +268,7 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
                     n['label'] = campaign
                     n['url'] = campaign_href
                     n['type'] = 'Campaign'
+                    n['id'] = campaign_id
                     nodes.append(n)
                     obj_graph[campaign_id] = (node_position, [obj_id])
                     node_position += 1

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -71,6 +71,30 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
             'color_highlight': '#FFC060',
             'color_highlight_border': '#FFA837'
         },
+        'Domain': {
+            'shape': 'dot',
+            'size': 20,
+            'color': '#33EB33',
+            'color_border': '#25C025',
+            'color_highlight': '#55FF55',
+            'color_highlight_border': '#33EB33'
+        },
+        'Email': {
+            'shape': 'dot',
+            'size': 25,
+            'color': '#FF8989',
+            'color_border': '#CF7070',
+            'color_highlight': '#FFB0B0',
+            'color_highlight_border': '#FF8989'
+        },
+        'Event': {
+            'shape': 'dot',
+            'size': 35,
+            'color': '#B05151',
+            'color_border': '#904040',
+            'color_highlight': '#D07171',
+            'color_highlight_border': '#B05151'
+        },
         'Exploit': {
             'shape': 'dot',
             'size': 10,
@@ -78,6 +102,22 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
             'color_border': '#709020',
             'color_highlight': '#A8CC60',
             'color_highlight_border': '#8CA336'
+        },
+        'Indicator': {
+            'shape': 'dot',
+            'size': 10,
+            'color': '#B08751',
+            'color_border': '#907050',
+            'color_highlight': '#CCA075',
+            'color_highlight_border': '#B08751'
+        },
+        'IP': {
+            'shape': 'dot',
+            'size': 20,
+            'color': '#90570C',
+            'color_border': '#77400C',
+            'color_highlight': '#B06037',
+            'color_highlight_border': '#90570C'
         },
         'PCAP': {
             'shape': 'dot',
@@ -95,30 +135,6 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
             'color_highlight': '#6090B8',
             'color_highlight_border': '#4A7797'
         },
-        'Target': {
-            'shape': 'dot',
-            'size': 10,
-            'color': '#4AA24A',
-            'color_border': '#308030',
-            'color_highlight': '#60C860',
-            'color_highlight_border': '#4AA24A'
-        },
-        'Indicator': {
-            'shape': 'dot',
-            'size': 10,
-            'color': '#B08751',
-            'color_border': '#907050',
-            'color_highlight': '#CCA075',
-            'color_highlight_border': '#B08751'
-        },
-        'Event': {
-            'shape': 'dot',
-            'size': 35,
-            'color': '#B05151',
-            'color_border': '#904040',
-            'color_highlight': '#D07171',
-            'color_highlight_border': '#B05151'
-        },
         'Sample': {
             'shape': 'dot',
             'size': 25,
@@ -127,29 +143,13 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
             'color_highlight': '#A0D0FF',
             'color_highlight_border': '#8CCBF8'
         },
-        'Email': {
+        'Target': {
             'shape': 'dot',
-            'size': 25,
-            'color': '#FF8989',
-            'color_border': '#CF7070',
-            'color_highlight': '#FFB0B0',
-            'color_highlight_border': '#FF8989'
-        },
-        'Domain': {
-            'shape': 'dot',
-            'size': 20,
-            'color': '#33EB33',
-            'color_border': '#25C025',
-            'color_highlight': '#55FF55',
-            'color_highlight_border': '#33EB33'
-        },
-        'IP': {
-            'shape': 'dot',
-            'size': 20,
-            'color': '#90570C',
-            'color_border': '#77400C',
-            'color_highlight': '#B06037',
-            'color_highlight_border': '#90570C'
+            'size': 10,
+            'color': '#4AA24A',
+            'color_border': '#308030',
+            'color_highlight': '#60C860',
+            'color_highlight_border': '#4AA24A'
         }
     }
 

--- a/relationships_service/handlers.py
+++ b/relationships_service/handlers.py
@@ -82,10 +82,10 @@ def gather_relationships(obj_type, obj_id, user, depth, types):
         'IP': {
             'shape': 'dot',
             'size': 20,
-            'color': '#90F70C',
-            'color_border': '#77C80C',
-            'color_highlight': '#B0FF37',
-            'color_highlight_border': '#90F70C'
+            'color': '#90570C',
+            'color_border': '#77400C',
+            'color_highlight': '#B06037',
+            'color_highlight_border': '#90570C'
         }
     }
 

--- a/relationships_service/templates/relationships_service_all_tab.html
+++ b/relationships_service/templates/relationships_service_all_tab.html
@@ -15,8 +15,6 @@ $(document).ready(function() {
     // default graph lists
     var nodes = [];
     var links = [];
-    //var labelAnchors = []; // used if we want to do force labels
-    //var labelAnchorLinks = []; // used if we want to do force labels
 
     $(document).on('click', '#change_graph', function(e) {
         //$('#graph_container').empty();
@@ -37,8 +35,6 @@ $(document).ready(function() {
                 if (data.success) {
                     nodes = data.message.nodes;
                     links = data.message.links;
-                    // labelAnchors = data.message.labelAnchors;
-                    // labelAnchorLinks = data.message.labelAnchorLinks;
                 }
             }
         });
@@ -108,47 +104,7 @@ $(document).ready(function() {
 
         var data_dump = "";
         var visjs_data = {nodes: new vis.DataSet(nodes), edges: new vis.DataSet(links)};
-
-        /*
-        var link = svg.selectAll("line.link")
-                   .data(links)
-                   .enter()
-                   .append("svg:line")
-                   .attr("class", "link")
-                   .style("stroke", "#CCC");
-
-        var node = svg.selectAll(".node")
-                   .data(nodes)
-                   .enter()
-                   .append("g")
-                   .attr("class", "node")
-                   .on("mouseover", mouseover)
-                   .on("mouseout", mouseout)
-                   .call(force.drag);
-
-        node.append("circle")
-            .attr("r", 8)
-            .style('stroke', '#CCC')
-            .style("fill", function(d) {
-                return d.color;
-            });
-       */
-
         var network = new vis.Network(visjs_container, visjs_data, visjs_options);
-
- /*
-        function mouseover() {
-          d3.select(this).select("circle").transition()
-              .duration(350)
-              .attr("r", 16);
-        }
-
-        function mouseout() {
-          d3.select(this).select("circle").transition()
-              .duration(350)
-              .attr("r", 8);
-        }
- */
 
         $('#draggable').show()
         .css({'position': 'absolute', 'top': 60, 'left' : 20});

--- a/relationships_service/templates/relationships_service_all_tab.html
+++ b/relationships_service/templates/relationships_service_all_tab.html
@@ -17,7 +17,7 @@ $(document).ready(function() {
     var links = [];
 
     $(document).on('click', '#change_graph', function(e) {
-        //$('#graph_container').empty();
+        $('#graph_container').empty();
         // get data from server.
         var depth = $('#node_depth').val();
         var types = $("#node_types option:selected").map(function(){return this.value}).get().join(",");

--- a/relationships_service/templates/relationships_service_all_tab.html
+++ b/relationships_service/templates/relationships_service_all_tab.html
@@ -7,12 +7,13 @@
 <script src="/js/vis.min.js"></script>
 <!-- vis.js components -->
 
-<script>
+<script type="text/javascript">
 
 $(document).ready(function() {
     $('#draggable').draggable();
     $('#graph_config').draggable();
     $('#graph_actions').draggable();
+
     // default graph lists
     var nodes = [];
     var links = [];
@@ -20,7 +21,7 @@ $(document).ready(function() {
     //var labelAnchorLinks = []; // used if we want to do force labels
 
     $(document).on('click', '#change_graph', function(e) {
-        $('#graph_container').empty();
+        //$('#graph_container').empty();
         // get data from server.
         var depth = $('#node_depth').val();
         var types = $("#node_types option:selected").map(function(){return this.value}).get().join(",");
@@ -98,37 +99,19 @@ $(document).ready(function() {
 
     function generate_graph(nodes, links) {
 
-        // define our graph and add to page
-        var w = 1000, h = 800;
+        var visjs_options = {
+            nodes: {borderWidth: 2, shadow: true},
+            edges: {width: 1,       shadow: true},
+            height: "800",
+            width: "1000"
+        }
 
-        var svg = d3.select("#svg_container > svg")
-        .attr("preserveAspectRatio", "xMidYMid meet")
-        .attr('width', w)
-        .attr('height', h)
-        .append('svg:g')
-        .call(d3.behavior.zoom().on("zoom", redraw))
-        .append('svg:g');
+        var visjs_container = document.getElementById('graph_container');
 
-        svg.append('svg:rect')
-        .attr('width', w)
-        .attr('height', h)
-        .attr('fill', 'white');
+        var data_dump = "";
+        var visjs_data = {nodes: new vis.DataSet(nodes), edges: new vis.DataSet(links)};
 
-        // define our forces
-        // force: node linking
-        var force = d3.layout.force()
-                    .nodes(nodes)
-                    .links(links)
-                    .size([w, h])
-                    .gravity(1)
-                    .linkDistance(100)
-                    .charge(-4000)
-                    .linkStrength(function(x) {
-                        return x.weight * 10;
-                    })
-                    .on("tick", tick)
-                    .start();
-
+        /*
         var link = svg.selectAll("line.link")
                    .data(links)
                    .enter()
@@ -151,48 +134,11 @@ $(document).ready(function() {
             .style("fill", function(d) {
                 return d.color;
             });
+       */
 
-        //node.append("text")
-        //    .attr("x", 12)
-        //    .attr("dy", ".35em")
-        //    .text(function(d) { return d.label; });
-        node.append("svg:a")
-        .attr("xlink:href", function(d) {
-            return d.url;
-        })
-        .append("svg:text")
-        .text(function(d) {
-            if (d.visible) {
-                if (d.campaign) {
-                    return d.label + " (" + d.campaign + ")";
-                } else {
-                    return d.label;
-                }
-            }
-        })
-        .style("fill", "#3399ff")
-        .style("font-family", "Arial")
-        .style("font-size", 12)
-        .attr("x", 12)
-        .attr("dy", ".35em");
+        var network = new vis.Network(visjs_container, visjs_data, visjs_options);
 
-        function redraw() {
-            svg.attr("transform",
-                "translate(" + d3.event.translate + ")"
-                + " scale(" + d3.event.scale + ")");
-        }
-
-        function tick() {
-          link
-              .attr("x1", function(d) { return d.source.x; })
-              .attr("y1", function(d) { return d.source.y; })
-              .attr("x2", function(d) { return d.target.x; })
-              .attr("y2", function(d) { return d.target.y; });
-
-          node
-              .attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; });
-        }
-
+ /*
         function mouseover() {
           d3.select(this).select("circle").transition()
               .duration(350)
@@ -204,6 +150,7 @@ $(document).ready(function() {
               .duration(350)
               .attr("r", 8);
         }
+ */
 
         $('#draggable').show()
         .css({'position': 'absolute', 'top': 60, 'left' : 20});
@@ -232,10 +179,12 @@ $(document).ready(function() {
     z-index: 5;
     float: right;
 }
-#svg_container {
+#graph_container {
     border: 1px solid #CCCCCC;
     margin-left: 150px;
     margin-right: 150px;
+    width: 800,
+    height: 1000
 }
 #graph_legend {
     margin-left: -15px;
@@ -243,8 +192,7 @@ $(document).ready(function() {
 </style>
 
 <div id="relationships_service" width="100%">
-    <div id="svg_container">
-        <svg id="graph_container"></svg>
+    <div id="graph_container">
     </div>
     <div id="graph_config" class="ui-widget-content" style="display: none;">
         <div style="vertical-align: top; padding-top: 8px;">Depth:

--- a/relationships_service/templates/relationships_service_all_tab.html
+++ b/relationships_service/templates/relationships_service_all_tab.html
@@ -1,6 +1,12 @@
 {% load url from future %}
 
 <script src="/js/d3.v2.min.js"></script>
+
+<!-- vis.js components -->
+<link href="/css/vis.min.css" rel="stylesheet" type="text/css" />
+<script src="/js/vis.min.js"></script>
+<!-- vis.js components -->
+
 <script>
 
 $(document).ready(function() {

--- a/relationships_service/templates/relationships_service_all_tab.html
+++ b/relationships_service/templates/relationships_service_all_tab.html
@@ -16,6 +16,8 @@ $(document).ready(function() {
     var nodes = [];
     var links = [];
 
+    $('#node_types').on('change', function() { $('#change_graph').trigger('click'); });
+
     $(document).on('click', '#change_graph', function(e) {
         $('#graph_container').empty();
         // get data from server.

--- a/relationships_service/templates/relationships_service_all_tab.html
+++ b/relationships_service/templates/relationships_service_all_tab.html
@@ -124,6 +124,9 @@ $(document).ready(function() {
 
         // Configure vis.js events
         network.on('selectNode', update_details);
+
+        // Reset the "details" box
+        $('#obj_details').html('<p><b>Details:</b></p>');
     };
 
     function update_details(obj) {

--- a/relationships_service/templates/relationships_service_all_tab.html
+++ b/relationships_service/templates/relationships_service_all_tab.html
@@ -1,7 +1,5 @@
 {% load url from future %}
 
-<script src="/js/d3.v2.min.js"></script>
-
 <!-- vis.js components -->
 <link href="/css/vis.min.css" rel="stylesheet" type="text/css" />
 <script src="/js/vis.min.js"></script>

--- a/relationships_service/templates/relationships_service_all_tab.html
+++ b/relationships_service/templates/relationships_service_all_tab.html
@@ -11,10 +11,15 @@ $(document).ready(function() {
     $('#draggable').draggable();
     $('#graph_config').draggable();
     $('#graph_actions').draggable();
+    $('#obj_details').draggable();
 
     // default graph lists
     var nodes = [];
     var links = [];
+
+    // var to hold the network graph object
+    var network = null;
+    var visjs_data = {};
 
     $('#node_types').on('change', function() { $('#change_graph').trigger('click'); });
 
@@ -105,8 +110,8 @@ $(document).ready(function() {
         var visjs_container = document.getElementById('graph_container');
 
         var data_dump = "";
-        var visjs_data = {nodes: new vis.DataSet(nodes), edges: new vis.DataSet(links)};
-        var network = new vis.Network(visjs_container, visjs_data, visjs_options);
+        visjs_data = {nodes: new vis.DataSet(nodes), edges: new vis.DataSet(links)};
+        network = new vis.Network(visjs_container, visjs_data, visjs_options);
 
         $('#draggable').show()
         .css({'position': 'absolute', 'top': 60, 'left' : 20});
@@ -114,7 +119,30 @@ $(document).ready(function() {
         .css({'position': 'absolute', 'top': 60, 'right' : 20});
         $('#graph_actions').show()
         .css({'position': 'absolute', 'top': 275, 'right' : 20});
-    }
+        $('#obj_details').show()
+        .css({'position': 'absolute', 'top': 500, 'left' : 20});
+
+        // Configure vis.js events
+        network.on('selectNode', update_details);
+    };
+
+    function update_details(obj) {
+        var selected_nodes = obj['nodes'];
+
+        // If the selection contains more than one node, or no nodes, then ignore
+        if(selected_nodes.length != 1) {
+           $('#obj_details').html('<p><b>Details:</b></p>');
+           return;
+        }
+
+        var selected_node_data = visjs_data['nodes'].get({filter: function(e, i, a) { return selected_nodes[0] == e['id']; }});
+        var html_details = "<p><b>Details:</b></p><p><ul>";
+        html_details += "<li>Type: " + selected_node_data[0]['group'] + "</li>";
+        html_details += "<li>Link: <a target=\"blank\" href=\"" + selected_node_data[0]['url'] + "\">" + selected_node_data[0]['id'] + "</a></li>";
+        html_details += "<li>Status: " + selected_node_data[0]['crits_status'] + "</li>";
+        html_details += "</ul></p>";
+        $('#obj_details').html(html_details);
+    };
 
 });
 
@@ -134,6 +162,12 @@ $(document).ready(function() {
     width: 100px;
     z-index: 5;
     float: right;
+}
+#obj_details {
+    width: 300px;
+    height: 200px;
+    z-index: 5;
+    float: left;
 }
 #graph_container {
     border: 1px solid #CCCCCC;
@@ -200,5 +234,8 @@ $(document).ready(function() {
             <li style="color: #8CCBF8;"><span style="color: #000;">Samples</span></li>
             <li style="color: #4AA24A;"><span style="color: #000;">Targets</span></li>
         </ul>
+    </div>
+    <div id="obj_details" class="ui-widget-content" style="display: none;">
+     <p><b>Details:</b></p>
     </div>
 </div>


### PR DESCRIPTION
Per @mgoffin, implementing a bunch of the CRITs relational stuff using vis.js in relationship_service, rather than the base project. Got the idea from @Magicked. I have some extended features still being worked, but I believe this should bring it up to feature-parity with the previous d3 implementation, albeit with a cleaner interface, less code, and a couple additional tweaks of our own. One small TODO would be to add more color schemes to the dict in handlers.py and also to modify the legend to chase the color scheme changes, where they occur.