### PR TITLE
Misc fixes for yara_service

### DIFF
--- a/yara_service/__init__.py
+++ b/yara_service/__init__.py
@@ -171,6 +171,7 @@ class YaraService(Service):
             except yara.SyntaxError as e:
                 message = "Yara rules file: %s: %s" % (sigfile, str(e))
                 logger.exception(message)
+                os.chdir(old)
                 raise ServiceConfigError(message)
             sigsets.append({'name': filename, 'rules': rules})
             os.chdir(old) 

--- a/yara_service/__init__.py
+++ b/yara_service/__init__.py
@@ -164,9 +164,9 @@ class YaraService(Service):
                 logger.exception("File cannot be opened: %s" % sigfile)
                 raise ServiceConfigError(str(e))
             try:
-                rules = yara.compile(source=data)
-            except yara.SyntaxError:
-                message = "Not a valid yara rules file: %s" % sigfile
+                rules = yara.compile(source=data, error_on_warning=False)
+            except yara.SyntaxError, e:
+                message = "Yara rules file: %s: %s" % (sigfile, str(e))
                 logger.exception(message)
                 raise ServiceConfigError(message)
             sigsets.append({'name': filename, 'rules': rules})

--- a/yara_service/handlers.py
+++ b/yara_service/handlers.py
@@ -45,6 +45,6 @@ def test_yara_rule(id_, rule):
             if mcount == 0:
                 yara_results.append("No matches!")
             message = pprint.pformat(yara_results)
-        except SyntaxError, e:
-            message = "Syntax error in YARA rule: %s" % e
+        except SyntaxError as e:
+            message = "Syntax error in YARA rule: %s" % str(e)
     return {"success": success, "message": message}


### PR DESCRIPTION
First fix:
Instead of having an error:
Misconfigured - Not a valid yara rules file: /path/to/yarasigs/foobar.yara
Now we get:
Misconfigured - Yara rules file: /path/to/yarasigs/foobar.yara: can't open include file: bazbar.yara

Second fix:
Previously the compilation of the yara rules was happening without changing directory to the spot where the rules physically reside, therefore all the includes assuming the current directory e.g.:
"include rulefile1.yara" 
would fail, because one would need to use the absolute path for any includes e.g.:
"include /absolute/path/to/rulefile1.yara"

This change allows the former to work, saving much headache from "administering" the yara rules.