### PR TITLE
Fix an exception when clicking the Preview button in taxii_service

### DIFF
--- a/taxii_service/forms.py
+++ b/taxii_service/forms.py
@@ -74,7 +74,7 @@ def filter_and_format_choices(choice_opts, item, _type):
             continue
         if item.id != obj.id or item_type != _type:
             # only process if the item isn't the current context crits item
-            ret_opts.append((choice, choice_fmt.format(obj)))
+            ret_opts.append((choice, choice_fmt.format(obj).encode('utf-8')))
     return ret_opts
 
 def get_supported_types():


### PR DESCRIPTION
```
DEBUG 2015-10-28 16:32:12,796 crits.core.errors ['Traceback (most recent call last):\n', '  File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py", line 112, in get_response\n    response = wrapped_callb
ack(request, *callback_args, **callback_kwargs)\n', '  File "/usr/lib/python2.7/dist-packages/django/contrib/auth/decorators.py", line 22, in _wrapped_view\n    return view_func(request, *args, **kwargs)\n', '  File "
/data/crits_services/taxii_service/views.py", line 33, in get_taxii_config_form\n    tform = forms.TAXIIForm(str(request.user.username), obj)\n', '  File "/data/crits_services/taxii_service/forms.py", line 41, in __in
it__\n    field.choices = filter_and_format_choices(collected, item, _type)\n', '  File "/data/crits_services/taxii_service/forms.py", line 77, in filter_and_format_choices\n    ret_opts.append((choice, choice_fmt.for
mat(obj)))\n', "UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-13: ordinal not in range(128)\n"]
```