### PR TITLE
TAXII: When migrating only delete fields that exist

### DIFF
--- a/taxii_service/__init__.py
+++ b/taxii_service/__init__.py
@@ -138,7 +138,8 @@ class TAXIIClient(Service):
                   'pword': '',
                   'feeds': feeds}
         for key in to_remove:
-            del existing_config[key]
+            if key in existing_config:
+                del existing_config[key]
         existing_config['taxii_servers'] = {'Migrated': server}
         return existing_config
 


### PR DESCRIPTION
Sometimes an expected field doesn't exist. Don't try to delete something that isn't there.