### PR TITLE
further related_type fixes

### DIFF
--- a/chminfo_service/__init__.py
+++ b/chminfo_service/__init__.py
@@ -235,6 +235,7 @@ class CHMInfoService(Service):
             for f in self.added_files:
                 handle_file(f[0], f[3], obj.source,
                             related_id=str(obj.id),
+                            related_type=str(obj._meta['crits_type']),
                             campaign=obj.campaign,
                             method=self.name,
                             relationship=RelationshipTypes.CONTAINED_WITHIN,

--- a/cuckoo_service/__init__.py
+++ b/cuckoo_service/__init__.py
@@ -498,7 +498,7 @@ class CuckooService(Service):
             self._info("New file: %s (%d bytes, %s)" % (name, len(data), h))
             handle_file(name, data, self.obj.source,
                         related_id=str(self.obj.id),
-                        related_type=str(obj._meta['crits_type']),
+                        related_type=str(self.obj._meta['crits_type']),
                         campaign=self.obj.campaign,
                         method=self.name,
                         relationship=RelationshipTypes.RELATED_TO,

--- a/malshare_service/__init__.py
+++ b/malshare_service/__init__.py
@@ -122,6 +122,7 @@ class MalShareService(Service):
             filename = obj.md5
             handle_file(filename, sample_file, obj.source,
                         related_id=str(obj.id),
+                        related_type=str(obj._meta['crits_type']),
                         campaign=obj.campaign,
                         method=self.name,
                         user=self.current_task.username)


### PR DESCRIPTION
A few more one-offs for missing or borked related_type in handle_file()