### PR TITLE
Add task submission options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.swo
 !passivetotal_service
+.idea

--- a/cuckoo_service/__init__.py
+++ b/cuckoo_service/__init__.py
@@ -199,16 +199,16 @@ class CuckooService(Service):
         machine = self.config.get('machine', "")
         if machine.lower() == "all":
             # Submit a new task with otherwise the same info to each machine
-            for each in self.get_machines():
-                task_id = self.post_task(files, payload, tags=tags, options=options)
+            for machine in self.get_machines():
+                task_id = self.post_task(files, payload, machine=machine, options=options)
                 if task_id is not None:
-                    tasks[each] = task_id
+                    tasks[machine] = task_id
         elif machine.lower() == "any":
             task_id = self.post_task(files, payload, tags=tags, options=options)
             if task_id is not None:
                 tasks['any'] = task_id
         elif machine:  # Only one Machine ID requested
-            task_id = self.post_task(files, payload, machine=machine, tags=tags, options=options)
+            task_id = self.post_task(files, payload, machine=machine, options=options)
             if task_id is not None:
                 tasks[machine] = task_id
 

--- a/cuckoo_service/__init__.py
+++ b/cuckoo_service/__init__.py
@@ -93,7 +93,7 @@ class CuckooService(Service):
             config['tor'] = False
         if 'procmemdump' not in config:
             config['procmemdump'] = False
-        
+
         # The integer values are submitted as a list for some reason.
         # Package and machine are submitted as a list too.
         data = { 'timeout': config['timeout'][0],
@@ -185,9 +185,11 @@ class CuckooService(Service):
             options['procmemdump'] = 'yes'
 
         options = ",".join(list(map(lambda option: "{0}={1}".format(option, options[option]), options.keys())))
-        options_string = str(self.config.get('options'))
-        if options_string:
-            options += options_string
+        custom_options = str(self.config.get('options'))
+        if custom_options:
+            if len(options) > 0:
+                options += ","
+            options += custom_options
 
         tags = str(self.config.get('tags'))
 

--- a/cuckoo_service/__init__.py
+++ b/cuckoo_service/__init__.py
@@ -4,7 +4,6 @@ from hashlib import md5
 import os
 import tarfile
 import time
-import logging
 
 import requests
 
@@ -90,6 +89,11 @@ class CuckooService(Service):
     def bind_runtime_form(analyst, config):
         machines = CuckooService._tuplize_machines(config['machine'])
 
+        if 'tor' not in config:
+            config['tor'] = False
+        if 'procmemdump' not in config:
+            config['procmemdump'] = False
+        
         # The integer values are submitted as a list for some reason.
         # Package and machine are submitted as a list too.
         data = { 'timeout': config['timeout'][0],
@@ -102,7 +106,6 @@ class CuckooService(Service):
                  'ignored_files': config['ignored_files'][0],
                  'machine': config['machine'][0],
                  'tags': config['tags'][0]}
-        logging.info(data)
 
         return forms.CuckooRunForm(machines=machines, data=data)
 

--- a/cuckoo_service/__init__.py
+++ b/cuckoo_service/__init__.py
@@ -180,7 +180,7 @@ class CuckooService(Service):
             options['procmemdump'] = 'yes'
 
         options = ",".join(list(map(lambda option: "{0}={1}".format(option, options[option]), options.keys())))
-        options_string = self.config.get('options')
+        options_string = str(self.config.get('options'))
         if options_string:
             options += options_string
 

--- a/cuckoo_service/__init__.py
+++ b/cuckoo_service/__init__.py
@@ -4,6 +4,7 @@ from hashlib import md5
 import os
 import tarfile
 import time
+import logging
 
 import requests
 
@@ -101,6 +102,7 @@ class CuckooService(Service):
                  'ignored_files': config['ignored_files'][0],
                  'machine': config['machine'][0],
                  'tags': config['tags'][0]}
+        logging.info(data)
 
         return forms.CuckooRunForm(machines=machines, data=data)
 

--- a/cuckoo_service/forms.py
+++ b/cuckoo_service/forms.py
@@ -70,7 +70,7 @@ class CuckooRunForm(forms.Form):
                                            " in the Cuckoo configuration.",
                                  initial=0)
     enforce_timeout = forms.BooleanField(required=False,
-                                         label="Enforce Timeout?",
+                                         label="Enforce timeout",
                                          initial=False,
                                          help_text="Always wait the timeout "
                                                    "period.")
@@ -79,6 +79,9 @@ class CuckooRunForm(forms.Form):
                               initial=[],
                               help_text="Name of the machine to use for the "
                                         "analysis.")
+    tags = forms.CharField(required=False,
+                           label="Machine tags",
+                           help_text="Machine tags separated by commas")
     package = forms.ChoiceField(required=True,
                                 label="Package",
                                 choices=[("auto", "auto"),
@@ -87,6 +90,14 @@ class CuckooRunForm(forms.Form):
                                          ("pdf", "pdf"),
                                          ("doc", "doc")],
                                 help_text="Analysis package to run.")
+    tor = forms.BooleanField(required=False,
+                             label="Use Tor",
+                             initial=False,
+                             help_text="Enable Tor while running this sample (cuckoo-modified fork feature)")
+    procmemdump = forms.BooleanField(required=False,
+                                     label="Analyze process memory",
+                                     initial=False,
+                                     help_text="Dump and analyze process memory (Processing takes longer)")
     existing_task_id = forms.IntegerField(required=False,
                                  label="Existing task ID",
                                  help_text="DEVELOPMENT ONLY: Fetch results "
@@ -94,6 +105,9 @@ class CuckooRunForm(forms.Form):
                                  "running the sample in the sandbox. Use '0' "
                                  "to run a new analysis.",
                                  initial=0)
+    options = forms.CharField(required=False,
+                              label="Options",
+                              help_text="A Cuckoo task options string (e.g. foo=yes,bar=yes)")
     ignored_files = forms.CharField(required=False,
                                     label="Ignored files",
                                     initial='SharedDataEvents*',

--- a/cuckoo_service/forms.py
+++ b/cuckoo_service/forms.py
@@ -69,6 +69,7 @@ class CuckooRunForm(forms.Form):
                                            "as 0 to use the timeout specified "
                                            " in the Cuckoo configuration.",
                                  initial=0)
+
     enforce_timeout = forms.BooleanField(required=False,
                                          label="Enforce timeout",
                                          initial=False,
@@ -82,6 +83,7 @@ class CuckooRunForm(forms.Form):
     tags = forms.CharField(required=False,
                            label="Machine tags",
                            help_text="Machine tags separated by commas")
+
     package = forms.ChoiceField(required=True,
                                 label="Package",
                                 choices=[("auto", "auto"),
@@ -90,14 +92,17 @@ class CuckooRunForm(forms.Form):
                                          ("pdf", "pdf"),
                                          ("doc", "doc")],
                                 help_text="Analysis package to run.")
+
     tor = forms.BooleanField(required=False,
                              label="Use Tor",
                              initial=False,
                              help_text="Enable Tor while running this sample (cuckoo-modified fork feature)")
+
     procmemdump = forms.BooleanField(required=False,
                                      label="Analyze process memory",
                                      initial=False,
                                      help_text="Dump and analyze process memory (Processing takes longer)")
+
     existing_task_id = forms.IntegerField(required=False,
                                  label="Existing task ID",
                                  help_text="DEVELOPMENT ONLY: Fetch results "
@@ -105,9 +110,11 @@ class CuckooRunForm(forms.Form):
                                  "running the sample in the sandbox. Use '0' "
                                  "to run a new analysis.",
                                  initial=0)
+
     options = forms.CharField(required=False,
                               label="Options",
                               help_text="A Cuckoo task options string (e.g. foo=yes,bar=yes)")
+
     ignored_files = forms.CharField(required=False,
                                     label="Ignored files",
                                     initial='SharedDataEvents*',


### PR DESCRIPTION
Adds the following options to the Cuckoo task submission form:

- Machine tags text field - Allows selecting a machine to use for analysis based on the machine tags assigned in Cuckoo. This is useful if you want to allow select from a pool of machines, but don't want to to select any machine.
- Process memory analysis checkbox - Configures the task to dump and analyze the process memory. These specific details are not reflected in the CRITs Cuckoo service results at this time, but are accessible via the Cuckoo web UI and API 
- Enable Tor checkbox - Enables Tor connectivity during analysis. Only applicable to a properly configured sandbox  running the [cuckoo-modified](https://github.com/spender-sandbox/cuckoo-modified) fork of Cuckoo.
- Custom options text field. Input of a Cuckoo options string (comma separated option=value), Which can be used for setting arbitrary task options, including custom options, and options which do not have a dedicated field in the submission form 

Also, the maximum wait time for analysis to complete is increased from 60 seconds to 120 seconds, to account for the additional processing time that is required when some options are used.