### PR TITLE
TAXII Service: Initialize config key taxii_servers as dict

### DIFF
--- a/taxii_service/forms.py
+++ b/taxii_service/forms.py
@@ -175,7 +175,7 @@ class TAXIIServiceConfigForm(forms.Form):
                      'style':"height:100px; background-image: none"}
     taxii_servers = forms.ChoiceField(required=False,
                   label="TAXII Servers",
-                  initial='',
+                  initial={},
                   widget=forms.Select(attrs=tserver_attrs))
 
     def __init__(self, choices=[], *args, **kwargs):

--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -1501,7 +1501,7 @@ def update_taxii_server_config(updates, analyst):
             pass
     elif 'edit_feed' in updates:
         data = servers[updates['srv_name']]['feeds'][updates['edit_feed']]
-        hostname = servers[updates['srv_name']]['hostname']
+        hostname = servers[updates['srv_name']].get('hostname', '')
         last = taxii.Taxii.get_last(hostname + ':' + data['feedname'])
         if last:
             data['last_poll'] = str(pytz.utc.localize(last.end)).split('+')[0]
@@ -1553,7 +1553,9 @@ def update_taxii_server_config(updates, analyst):
                             fid += 1
                     feeds[str(fid)] = updates
                     servers[srv_name]['feeds'] = feeds
-                except KeyError:
+                except (KeyError, TypeError):
+                    if not isinstance(servers, dict):
+                        servers = {}
                     servers[srv_name] = {'feeds': {'0': updates}}
 
                 service.config.taxii_servers = servers


### PR DESCRIPTION
The taxii_service key of the service config was being initialized as an empty string when it should have been a dictionary instead.  Key is now initialized as a dict and improved error handling will fix it if it's not a dict.  Also fixed a error that would occur if the hostname had not yet been set.