### PR TITLE
Split the 'sender', 'reply_to', 'from_address' fields in TAXII Service

### DIFF
--- a/taxii_service/parsers.py
+++ b/taxii_service/parsers.py
@@ -1060,11 +1060,11 @@ class STIXParser():
                                     id_list.append(tmp_obj.id_)
                             else:
                                 imp_type = 'Indicator'
-                                if key in 'reply_to':
+                                if 'reply_to' in key:
                                     ind_type = IndicatorTypes.EMAIL_REPLY_TO
-                                elif key in 'sender':
+                                elif 'sender' in key:
                                     ind_type = IndicatorTypes.EMAIL_SENDER
-                                elif key in 'from_address':
+                                elif 'from_address' in key:
                                     ind_type = IndicatorTypes.EMAIL_FROM
                                 elif 'subject' in key:
                                     ind_type = IndicatorTypes.EMAIL_SUBJECT

--- a/taxii_service/parsers.py
+++ b/taxii_service/parsers.py
@@ -1060,8 +1060,12 @@ class STIXParser():
                                     id_list.append(tmp_obj.id_)
                             else:
                                 imp_type = 'Indicator'
-                                if key in ('sender', 'reply_to', 'from_address'):
-                                    ind_type = IndicatorTypes.EMAIL_ADDRESS
+                                if key in 'reply_to':
+                                    ind_type = IndicatorTypes.EMAIL_REPLY_TO
+                                elif key in 'sender':
+                                    ind_type = IndicatorTypes.EMAIL_SENDER
+                                elif key in 'from_address':
+                                    ind_type = IndicatorTypes.EMAIL_FROM
                                 elif 'subject' in key:
                                     ind_type = IndicatorTypes.EMAIL_SUBJECT
                                 elif 'x_mailer' in key:


### PR DESCRIPTION
Split the 'sender', 'reply_to', 'from_address' fields into the more specific versions of email addresses.