### PR TITLE
TAXII: Confidence/Impact Improvements

### DIFF
--- a/crits_scripts/scripts/standards_import.py
+++ b/crits_scripts/scripts/standards_import.py
@@ -31,7 +31,7 @@ class CRITsScript(CRITsBaseScript):
         data = f.read()
         f.close()
 
-        ret = import_standards_doc(data, "Command Line", "Standards Import Script", make_event=opts.event, source=opts.source)
+        ret = import_standards_doc(data, "Command Line", "Standards Import Script", hdr_events=opts.event, source=opts.source)
         if ret['success']:
             for k in ["events", "samples", "emails", "indicators"]:
                 print "%s (%i)" % (k, len(ret[k]))

--- a/taxii_service/forms.py
+++ b/taxii_service/forms.py
@@ -295,12 +295,10 @@ class TAXIIFeedConfigForm(forms.Form):
                           initial='',
                           widget=forms.HiddenInput())
 
-    source = forms.CharField(required=False,
-                             label="CRITs Source",
-                             initial='',
-                             widget=forms.TextInput(),
-                             help_text="The CRITs Source name to associate"
-                                       " with this feed.")
+    source = forms.ChoiceField(required=True,
+                               label="CRITs Source",
+                               help_text="The CRITs Source name to associate"
+                                         " with this feed.")
 
     fcert = forms.CharField(required=False,
                             label="Encryption Certificate",
@@ -329,10 +327,13 @@ class TAXIIFeedConfigForm(forms.Form):
                             help_text="The end timestamp of the last full "
                             "poll. Future polls begin with this date/time.")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, username, *args, **kwargs):
         kwargs.setdefault('label_suffix', ':')
         super(TAXIIFeedConfigForm, self).__init__(*args, **kwargs)
 
+        srcs = get_source_names(True, True, username)
+        self.fields['source'].choices = [(c.name, c.name) for c in srcs]
+        self.fields['source'].initial = get_user_organization(username)
 
 class UploadStandardsForm(forms.Form):
     """
@@ -349,8 +350,7 @@ class UploadStandardsForm(forms.Form):
     def __init__(self, username, *args, **kwargs):
         kwargs.setdefault('label_suffix', ':')
         super(UploadStandardsForm, self).__init__(*args, **kwargs)
-        self.fields['source'].choices = [(c.name,
-                                          c.name) for c in get_source_names(True,
-                                                                            True,
-                                                                            username)]
+
+        srcs = get_source_names(True, True, username)
+        self.fields['source'].choices = [(c.name, c.name) for c in srcs]
         self.fields['source'].initial = get_user_organization(username)

--- a/taxii_service/forms.py
+++ b/taxii_service/forms.py
@@ -7,6 +7,7 @@ from crits.core.user_tools import user_sources, get_user_organization
 from crits.core.handlers import get_source_names, collect_objects
 from crits.core.class_mapper import class_from_type
 from crits.services.handlers import get_config
+from crits.vocabulary.indicators import IndicatorCI
 
 from datetime import datetime
 from dateutil.tz import tzutc
@@ -327,6 +328,16 @@ class TAXIIFeedConfigForm(forms.Form):
                             help_text="The end timestamp of the last full "
                             "poll. Future polls begin with this date/time.")
 
+    def_conf = forms.ChoiceField(required=True,
+                                 label="Default Confidence",
+                                 help_text="Indicators with no Confidence "
+                                           "are assigned this value.")
+
+    def_impact = forms.ChoiceField(required=True,
+                                   label="Default Impact",
+                                   help_text="Indicators with no Impact "
+                                             "are assigned this value.")
+
     def __init__(self, username, *args, **kwargs):
         kwargs.setdefault('label_suffix', ':')
         super(TAXIIFeedConfigForm, self).__init__(*args, **kwargs)
@@ -334,6 +345,13 @@ class TAXIIFeedConfigForm(forms.Form):
         srcs = get_source_names(True, True, username)
         self.fields['source'].choices = [(c.name, c.name) for c in srcs]
         self.fields['source'].initial = get_user_organization(username)
+
+        ind_ci = IndicatorCI.values()
+        self.fields['def_conf'].choices = [(c, c.title()) for c in ind_ci]
+        self.fields['def_conf'].initial = 'unknown'
+        self.fields['def_impact'].choices = [(c, c.title()) for c in ind_ci]
+        self.fields['def_impact'].initial = 'unknown'
+
 
 class UploadStandardsForm(forms.Form):
     """

--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -747,7 +747,10 @@ def import_content_blocks(block_ids, action, analyst):
             if tsrvs[svr].get('hostname') == block.hostname:
                 for feed in tsrvs[svr]['feeds']:
                     if tsrvs[svr]['feeds'][feed]['feedname'] == block.feed:
-                        source = tsrvs[svr]['feeds'][feed]['source']
+                        feed_cfg = tsrvs[svr]['feeds'][feed]
+                        source = feed_cfg['source']
+                        default_ci = (feed_cfg.get('def_conf', 'unknown'),
+                                      feed_cfg.get('def_impact', 'unknown'))
                         break
                 if source:
                     break
@@ -756,9 +759,10 @@ def import_content_blocks(block_ids, action, analyst):
                 source = block.hostname.split(' - Source: ')[1]
             except:
                 source = block.hostname
+            default_ci = ('unknown', 'unknown')
 
-        objs = import_standards_doc(data, analyst, method, ref=reference,
-                                    hdr_events=hdr_events, source=source)
+        objs = import_standards_doc(data, analyst, method, reference,
+                                    hdr_events, default_ci, source)
 
         if not objs['success']:
             ret['failures'].append((objs['reason'],
@@ -1757,7 +1761,7 @@ def update_taxii_service_config(post_data, analyst):
     return status
 
 def import_standards_doc(data, analyst, method, ref=None, hdr_events=False,
-                         source=None, preview_only=False):
+                         def_ci=None, source=None, preview_only=False):
     """
     Import a standards document into CRITs.
 
@@ -1772,6 +1776,8 @@ def import_standards_doc(data, analyst, method, ref=None, hdr_events=False,
     :type ref: str
     :param hdr_events: Whether or not we should make an Event for this document.
     :type hdr_events: bool
+    :param def_ci: The default Indicator (confidence, impact).
+    :type def_ci: tuple
     :param source: The name of the source who provided this document.
     :type source: str
     :param preview_only: If True, nothing is imported and a preview is returned
@@ -1791,7 +1797,7 @@ def import_standards_doc(data, analyst, method, ref=None, hdr_events=False,
           }
 
     try:
-        parser = STIXParser(data, analyst, method, preview_only)
+        parser = STIXParser(data, analyst, method, def_ci, preview_only)
         parser.parse_stix(reference=ref, hdr_events=hdr_events, source=source)
         parser.relate_objects()
     except STIXParserException, e:

--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -969,6 +969,14 @@ def to_stix_indicator(obj):
     obs, releas = to_cybox_observable(obj)
     for ob in obs:
         ind.add_observable(ob)
+        try:
+            ind.confidence = obj.confidence.rating.title()
+        except:
+            pass
+        try:
+            ind.likely_impact = obj.impact.rating.title()
+        except:
+            pass
     #TODO: determine if a source wants its name shared. This will
     #   probably have to happen on a per-source basis rather than a per-
     #   object basis.

--- a/taxii_service/views.py
+++ b/taxii_service/views.py
@@ -321,7 +321,7 @@ def configure_taxii(request, server=None):
     analyst = request.user.username
     srvr_form = forms.TAXIIServerConfigForm([(x,'') for x in range(100)],
                                             request.POST or None)
-    feed_form = forms.TAXIIFeedConfigForm(request.POST or None)
+    feed_form = forms.TAXIIFeedConfigForm(analyst, request.POST or None)
     if request.method == "POST" and request.is_ajax():
         if ('remove_server' in request.POST or
             'remove_feed' in request.POST or

--- a/taxii_service/views.py
+++ b/taxii_service/views.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import re
+from datetime import datetime
 
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
@@ -304,7 +305,8 @@ def get_taxii_result(request, crits_type, crits_id, preview):
         if preview and data and 'preview' in data:
             resp = HttpResponse(data['preview'],
                                 content_type="application/xml")
-            c_disp = 'attachment; filename="STIX_preview.xml"'
+            utcnow = datetime.utcnow().strftime('%Y%m%dT%H%M%S')
+            c_disp = 'attachment; filename="stix_preview-%s.xml"' % utcnow
             resp['Content-Disposition'] = c_disp
             return resp
         else: # else show success/error message that has been generated


### PR DESCRIPTION
Didn't have time to test this super thoroughly yet, so please provide feedback.
- Allow a user to configure a default Indicator confidence/impact by feed.  If the imported STIX Indicator doesn't specify confidence or likely_impact, the default values will be used.
- Add an CRITs Indicator's confidence/impact to the STIX output.
- Use a dropdown for Source in feed configuration instead of just a textbook
- Add a timestamp to the STIX preview filename