### PR TITLE
Spelling error for Red Hat requirements - tcpdump

### DIFF
--- a/threatexchange/bootstrap
+++ b/threatexchange/bootstrap
@@ -68,7 +68,7 @@ freebsd_install()
 red_hat_install()
 {
     #printf "${HEAD}Installing Yum Packages${END}\n"
-    sudo yum install itcpdump wireshark
+    sudo yum install tcpdump wireshark
     if [ $? -eq 0 ]
     then
       printf "${PASS}Yum Install Complete${END}\n"


### PR DESCRIPTION
threatexchange plugin

In the bootstrap file for the Threat Exchange plugin, there is a spelling error for the requirement 'tcpdump' under the Red Hat section.
The incorrect command is 'itcpdump' 
