### PR TITLE
TAXII: Fix Default Confidence/Impact Values in Feeds Form

### DIFF
--- a/taxii_service/__init__.py
+++ b/taxii_service/__init__.py
@@ -10,7 +10,7 @@ from crits.services.core import Service, ServiceConfigError
 
 from . import forms
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("crits." + __name__)
 
 class TAXIIClient(Service):
     """

--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -53,7 +53,7 @@ from crits.services.service import CRITsService
 from crits.vocabulary.ips import IPTypes
 from crits.vocabulary.relationships import RelationshipTypes
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("crits." + __name__)
 
 def poll_taxii_feeds(feeds, analyst, begin=None, end=None):
     """

--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -1618,6 +1618,9 @@ def update_taxii_server_config(updates, analyst):
         except:
             pass
     elif 'edit_feed' in updates:
+        if not updates['edit_feed']:
+            result['success'] = False
+            return result
         data = servers[updates['srv_name']]['feeds'][updates['edit_feed']]
         hostname = servers[updates['srv_name']].get('hostname', '')
         last = taxii.Taxii.get_last(hostname + ':' + data['feedname'])

--- a/taxii_service/templates/taxii_server_config.html
+++ b/taxii_service/templates/taxii_server_config.html
@@ -75,6 +75,10 @@ $('#add').click(function() {
 	}});
 $('#edit').click(function() {
     $("#error_box").html('');
+    if (!$('#id_feeds').val()) {
+        $('#error_box').text('You must select a feed to edit.');
+        return;
+    }
     if ($('#id_cur_sname').val()) {
         var data = {'edit_feed': $('#id_feeds').val(), 'srv_name': $('#id_cur_sname').val()};
     }
@@ -89,13 +93,18 @@ $('#edit').click(function() {
                     $('#id_fcert').val(data.fcert);
                     $('#id_fkey').val(data.fkey);
                     $('#id_subID').val(data.subID);
+                    $('#id_def_conf').val(data.def_conf);
+                    $('#id_def_impact').val(data.def_impact);
                     $('#id_last_poll').val(data.last_poll);
+
+                    if ($("#server_config_container").is(":visible")) {
+                        $("#server_config_container").slideToggle();
+                        $("#feed_config_container").slideToggle();
+                    }
                 }
-                else {$('#error_box').text('Failed to edit feed.');}}});
-	if ($("#server_config_container").is(":visible")) {
-		    $("#server_config_container").slideToggle();
-            $("#feed_config_container").slideToggle();
-	}});
+                else {$('#error_box').text('Failed to edit feed.');}
+            }});
+	});
 $('#remove').click(function() {
     if ($('#id_cur_sname').val()) {
         var data = {'remove_feed': $('#id_feeds').val(), 'srv_name': $('#id_cur_sname').val()};

--- a/taxii_service/views.py
+++ b/taxii_service/views.py
@@ -16,7 +16,7 @@ from crits.core.user_tools import user_can_view_data
 from . import handlers
 from . import forms
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("crits." + __name__)
 
 @user_passes_test(user_can_view_data)
 def taxii_poll(request):


### PR DESCRIPTION
When the Feeds form is loaded, it doesn't populate the Default Indicator Confidence/Impact fields with the values in the database.  Selecting values and submitting the form will correctly update the database, but if the form is fully reloaded, the values will go back to their initial setting (unknown).  This corrects that behavior.

Additionally, this handles the case where a user doesn't select a feed prior to clicking the `Edit Selected` button, and fixes the `No handlers could be found for logger...` errors by having it use the standard CRITs logger handler.