### PR TITLE
TAXII: Use Default Confidence/Impact for Any New CRITs Indicator

### DIFF
--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -395,6 +395,12 @@ def parse_content_block(content_block, tm_, privkey=None, pubkey=None):
     :type pubkey: string
     :returns: tuple: (parsed_data or None, error_message or None)
     """
+    stix_bindings = (t.CB_STIX_XML_10,
+                     t.CB_STIX_XML_101,
+                     t.CB_STIX_XML_11,
+                     t.CB_STIX_XML_111,
+                     "urn:stix.mitre.org:xml:1.2")
+
     binding = str(content_block.content_binding)
     if binding == 'application/x-pkcs7-mime':
         if not privkey or not pubkey:
@@ -414,7 +420,7 @@ def parse_content_block(content_block, tm_, privkey=None, pubkey=None):
         f.close()
         return parse_content_block(tm_.ContentBlock.from_xml(new_block),
                                    tm_, privkey, pubkey)
-    elif binding in (t.CB_STIX_XML_111, "urn:stix.mitre.org:xml:1.2"):
+    elif binding in stix_bindings:
         f = BytesIO(content_block.content)
         data = f.read()
         f.close()

--- a/taxii_service/parsers.py
+++ b/taxii_service/parsers.py
@@ -710,8 +710,8 @@ class STIXParser():
         """
 
         # Setup indicator confidence/impact
-        if not ind_ci:
-            ind_ci = (None, None)
+        if not ind_ci: # if not provided, use defaults
+            ind_ci = self.def_ci
 
         # check for missing attributes
         if not cbx_obj or not cbx_obj.properties:


### PR DESCRIPTION
The code currently only sets values for CRITs Indicator Confidence/Impact if the STIX Observable being imported is part of an actual STIX Indicator. However, because CRITs doesn't have a way to store a non-indicator STIX URL Observable, we are pretty much forced to make it a CRITs Indicator.  This change will use a feed's default confidence/impact settings anytime a CRITs Indicator is created from some content of that feed.