### PR TITLE
Office_Meta: Encode property values with UTF-8

### DIFF
--- a/office_meta_service/office_meta.py
+++ b/office_meta_service/office_meta.py
@@ -255,6 +255,8 @@ class OfficeParser(object):
                     prop['value'] = prop_data[offset+8: offset+8+(prop['str_len'] * 2)]
                 else:
                     prop['value'] = binascii.hexlify(prop_data[:8])
+                if isinstance(prop['value'], str):
+                    prop['value'] = prop['value'].decode('cp1252').encode('utf-8')
                 prop['result'] = "%s: %s" % (prop['name'], prop['value'])
                 if prop['id'] == 0x01:
                     properties['code_page'] = prop['result']


### PR DESCRIPTION
I kept getting an error like the following when running office_meta on some Samples:
`InvalidStringData: strings in documents must be valid UTF-8: 'Presentation Target: \xd4\xda\xc6\xc1\xd4\xda\xc6\xc1\xd4\xda\xc6\xc1'`
It seems those hex values aren't valid UTF-8, so MongoDB, which uses BSON, doesn't like it.

It makes sense that an MS Office document property value wouldn't be encoded in UTF-8 since Windows typically uses CP-1252.
The quick fix is to check if it's an encoded string, then decode it from CP-1252 and re-encode it to UTF-8.

While this appears to solve the problem, I was hoping someone having a bit more familiarity with this code would take a look and make sure I'm on the right track here.  Thanks!