### PR TITLE
Changed stix import statement

### DIFF
--- a/taxii_service/handlers.py
+++ b/taxii_service/handlers.py
@@ -15,7 +15,7 @@ import libtaxii as t
 import libtaxii.clients as tc
 import libtaxii.messages as tm
 import libtaxii.messages_11 as tm11
-from stix.utils import set_id_namespace
+from mixbox.idgen import set_id_namespace
 
 from django.conf import settings
 from django import forms as dforms

--- a/taxii_service/requirements.txt
+++ b/taxii_service/requirements.txt
@@ -3,3 +3,4 @@ libtaxii==1.1.109
 cybox==2.1.0.12
 stix==1.2.0.0
 stix-ramrod==1.1.0
+mixbox


### PR DESCRIPTION
Changed the import statement from stix.utils.set_id_namespace to
mixbox.idgen.set_id_namespace. Fixes import issues

This issue prevented the taxii_service from being used in crits