### PR TITLE
Added the Yara Python module to yara_service

### DIFF
--- a/yara_service/bootstrap
+++ b/yara_service/bootstrap
@@ -81,6 +81,7 @@ centos_install()
 {
     #printf "${HEAD}Installing Yum Packages${END}\n"
     sudo yum install yara
+    sudo pip install yara-python
     if [ $? -eq 0 ]
     then
       printf "${PASS}Yum Install Complete${END}\n"


### PR DESCRIPTION
I was getting the following error:
```
Failed to import '/usr/lib/libyara.so'
PATH = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin;/usr/lib
Failed to import '/usr/lib/libyara.so'
PATH = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin;/usr/lib;/usr/lib
Failed to import '/usr/lib/libyara.so'
PATH = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin;/usr/lib;/usr/lib;/usr/lib
Failed to import '/usr/lib/libyara.so'
PATH = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin;/usr/lib;/usr/lib;/usr/lib;/usr/lib
Unhandled exception in thread started by <function wrapper at 0x5316578>
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/django/utils/autoreload.py", line 229, in wrapper
    fn(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/django/core/management/commands/runserver.py", line 107, in inner_run
    autoreload.raise_last_exception()
  File "/usr/lib/python2.7/site-packages/django/utils/autoreload.py", line 252, in raise_last_exception
    six.reraise(*_exception)
  File "/usr/lib/python2.7/site-packages/django/utils/autoreload.py", line 229, in wrapper
    fn(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/lib/python2.7/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/usr/lib/python2.7/site-packages/django/apps/config.py", line 86, in create
    module = import_module(entry)
  File "/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/root/crits/crits/services/__init__.py", line 3, in <module>
    manager = svc_manager()
  File "/root/crits/crits/services/core.py", line 51, in __init__
    self._import_services(services_packages)
  File "/root/crits/crits/services/core.py", line 72, in _import_services
    import_module(services_pkg)
  File "/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/data/crits_services/ratdecoder_service/__init__.py", line 15, in <module>
    import yara
  File "/usr/lib/python2.7/site-packages/yara/__init__.py", line 7, in <module>
    from yara.rules import compile
  File "/usr/lib/python2.7/site-packages/yara/rules.py", line 17, in <module>
    from yara.libyara_wrapper import *
  File "/usr/lib/python2.7/site-packages/yara/libyara_wrapper.py", line 315, in <module>
    libyaradll = cdll.LoadLibrary(library)
  File "/usr/lib64/python2.7/ctypes/__init__.py", line 438, in LoadLibrary
    return self._dlltype(name)
  File "/usr/lib64/python2.7/ctypes/__init__.py", line 360, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libpcre.so.3: cannot open shared object file: No such file or directory
```
This was resolved by installing the Yara Python module via `pip install yara-python`.