### PR TITLE
Allow the service to run on Office 2007+ documents

### DIFF
--- a/maliciousmacrobot_service/__init__.py
+++ b/maliciousmacrobot_service/__init__.py
@@ -41,7 +41,7 @@ class MMBotService(Service):
     @staticmethod
     def valid_for(obj):
         # Only run on Office files
-        if not obj.is_office():
+        if not (obj.is_office() or obj.mimetype.startswith('application/vnd.openxmlformats-officedocument')):
             raise ServiceConfigError("Not a valid Office file.")
 
     @classmethod


### PR DESCRIPTION
Using partial match on obj.mimetype to allow Office 2007+ documents ti be in scope.

The tests in mmbot package use Office 2007+ documents. 