### PR TITLE
fix bug on preview_service & pdf2txt_service & macro_extract_service

### DIFF
--- a/macro_extract_service/__init__.py
+++ b/macro_extract_service/__init__.py
@@ -59,8 +59,8 @@ class MacroExtractService(Service):
                 if result['success']:
                     obj.add_relationship(
                         result['object'],
-                        RelationshipTypes.RELATED_TO,
-                        analyst=username,
+                        RelationshipTypes.CONTAINED_WITHIN,
+                        analyst=username.username,
                         rel_reason="Extracted from related Sample"
                     )
                     obj.save()

--- a/pdf2txt_service/__init__.py
+++ b/pdf2txt_service/__init__.py
@@ -167,11 +167,12 @@ class pdf2txtService(Service):
             self._warning("obj.id: %s, raw_id:%s, suc: %s" % (str(obj.id), str(raw_obj.id), repr(res['success']) ) )
             # update relationship if a related top-level object is supplied
             rel_type = RelationshipTypes.RELATED_TO
+            rel_type = RelationshipTypes.CONTAINED_WITHIN #bug in crits, display contains instead of contained within ...
             if obj.id != raw_obj.id: #don't form relationship to itself
                 resy = obj.add_relationship(rel_item=raw_obj,
                                         rel_type=rel_type,
-                                        rel_date=datetime.now(),
-                                        analyst=self.current_task.user)
+                                        rel_date=datetime.now()) #,
+                                        #analyst=self.current_task.user) #remove analyste because make error: Error running service: Cannot encode object: <SimpleLazyObject: <CRITsUser: $user>>
                 obj.save(username=self.current_task.user.username)
                 raw_obj.save(username=self.current_task.user.username)
                 self._warning("resy: %s" % (str(resy)) )

--- a/preview_service/__init__.py
+++ b/preview_service/__init__.py
@@ -58,6 +58,8 @@ class previewService(Service):
         if not 'antiword' in antiword_path.lower():
             raise ServiceConfigError("Executable does not appear to be antiword.")
 
+        tlp_value = config.get("tlp_value", "")
+
     @staticmethod
     def get_config(existing_config):
         # Generate default config from form and initial values.
@@ -75,7 +77,8 @@ class previewService(Service):
     @staticmethod
     def get_config_details(config):
         return {'pdftoppm_path': config['pdftoppm_path'],
-                'antiword_path': config['antiword_path']}
+                'antiword_path': config['antiword_path'],
+                'tlp_value': config['tlp_value']}
 
     @classmethod
     def generate_config_form(self, config):
@@ -117,6 +120,7 @@ class previewService(Service):
         obj.filedata.seek(0)
         data8 = obj.filedata.read(8)
         obj.filedata.seek(0)
+        tlp_value = self.config.get("tlp_value", "tlp_value")
         if not obj.is_pdf() and not data8.startswith("\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"):
             self._debug("preview image started.")
             try:
@@ -138,10 +142,11 @@ class previewService(Service):
                                                          method=self.name,
                                                          source=obj.source,
                                                          reference=None, 
-                                                         analyst=self.current_task.user, 
+                                                         analyst=self.current_task.user.username, 
                                                          screenshot=ofile, 
                                                          screenshot_ids=None,
                                                          oid=obj.id, 
+                                                         tlp=tlp_value,
                                                          otype="Sample")
                 if res.get('message') and res.get('success') == True:
                     self._warning("res-message: %s id:%s" % (res.get('message'), res.get('id') ) ) 
@@ -190,10 +195,11 @@ class previewService(Service):
                                                          method=self.name,
                                                          source=obj.source,
                                                          reference=None,
-                                                         analyst=self.current_task.user,
+                                                         analyst=self.current_task.user.username,
                                                          screenshot=fileh,
                                                          screenshot_ids=None,
                                                          oid=obj.id,
+                                                         tlp=tlp_value,
                                                          otype="Sample")
                             if res.get('message') and res.get('success') == True:
                                 self._warning("res-message: %s id:%s" % (res.get('message'), res.get('id') ) )
@@ -236,10 +242,11 @@ class previewService(Service):
                                                          method=self.name,
                                                          source=obj.source,
                                                          reference=None, 
-                                                         analyst=self.current_task.user, 
+                                                         analyst=self.current_task.user.username, 
                                                          screenshot=fileh, 
                                                          screenshot_ids=None,
                                                          oid=obj.id, 
+                                                         tlp=tlp_value,
                                                          otype="Sample")
                         if res.get('message') and res.get('success') == True:
                             self._warning("res-message: %s id:%s" % (res.get('message'), res.get('id') ) )

--- a/preview_service/forms.py
+++ b/preview_service/forms.py
@@ -15,6 +15,13 @@ class previewConfigForm(forms.Form):
                                widget=forms.TextInput(),
                                help_text="Full path to antiword binary.")
 
+    tlp_value = forms.CharField(required=True,
+                               label="Tlp value",
+                               initial='red',
+                               widget=forms.TextInput(),
+                               help_text="Indicate TLP value.")
+                               
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('label_suffix', ':')
         super(previewConfigForm, self).__init__(*args, **kwargs)
+


### PR DESCRIPTION
I added corection for service extract_macro and pdf2file.
I had error when run command: "Error running service: Cannot encode object: <SimpleLazyObject: <CRITsUser: lionel>>".
When remove field 'analyst' to call function "obj.add_relationship", that error disappear.
I changed RelationshipTypes RELATED_TO by CONTAINED_WITHIN, but crits display relationtype "Contains" instead of "contained within"...

fix realationship error in macro_extract -- cause username object

preview service fix bug tlp and username in call add_screenshot