### PR TITLE
Updated to visit requirements.txt files if there's no bootstrap file

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -15,6 +15,8 @@ END=$(tput sgr0)   #ends color
 #============================================================
 PIP='pip'
 
+. ./funcs.sh
+
 verify()
 {
     printf "${INFO}Testing Computer's Architecture${END}\n"
@@ -84,7 +86,7 @@ traversing_install()
                 printf "${INFO}Installing dependencies for ${fbname}${END}\n"
                 cd ${serv};
                 ./bootstrap
-                if [ $? -ne 0 ]
+                if [ $? -ne 0 ];
                 then
                     printf "${FAIL}bootstrap failed for ${fbname}!${END}\n"
                     exit
@@ -92,13 +94,28 @@ traversing_install()
                     printf "${PASS}bootstrap complete for ${fbname}${END}\n"
                 fi
                 cd ${tpwd}
+            else
+                if [ -f ${serv}/requirements.txt ];
+                then
+                    printf "${INFO}Installing python dependencies for ${fbname}${END}\n"
+                    cd ${serv};
+                    depend_crits
+                    if [ $? -ne 0 ];
+                    then
+                        printf "${FAIL}bootstrap failed for ${fbname}!${END}\n"
+                        exit
+                    else
+                        printf "${PASS}bootstrap complete for ${fbname}${END}\n"
+                    fi
+                    cd ${tpwd}
+                fi
             fi
         fi
     done
     printf "${INFO}bootstrap finished!\nDependencies for the following \
     services need some manual setup (at least until somebody fixes them):\
     \n- chopshop_service\n- metacap_service (it needs chopshop)\n- pyew\n\
-    - snugglefish_service\n- taxii_service${END}\n"
+    - taxii_service${END}\n"
 }
 
 # Error Message


### PR DESCRIPTION
The bootstrap file in the service's folder should install the dependencies from requirements.txt. There are some services that don't have bootstrap file, but there are requirements.txt files which should be used when bootstraping