### PR TITLE
Update dependency for passivetotal

### DIFF
--- a/passivetotal_service/requirements.txt
+++ b/passivetotal_service/requirements.txt
@@ -1,1 +1,1 @@
-passivetotal
+passivetotal<1.0.25


### PR DESCRIPTION
On versions above 1.0.24, importing DnsResponse fails.