### PR TITLE
Make sure that pymongo 3.4+ doesn't try to create indexes all the time

### DIFF
--- a/taxii_service/taxii.py
+++ b/taxii_service/taxii.py
@@ -16,6 +16,7 @@ class Taxii(CritsSchemaDocument, CritsDocument, Document):
         # (See http://mongoengine-odm.readthedocs.org/en/latest/guide/defining-documents.html#working-with-existing-data)
         "allow_inheritance": False,
         "collection": 'taxii',
+        "auto_create_index": False,
         "crits_type": 'TAXII',
         "latest_schema_version": 1,
         #NOTE: minify_defaults fields should match the MongoEngine field names, NOT the database fields
@@ -53,6 +54,7 @@ class TaxiiContent(CritsSchemaDocument, CritsDocument, Document):
         # (See http://mongoengine-odm.readthedocs.org/en/latest/guide/defining-documents.html#working-with-existing-data)
         "allow_inheritance": False,
         "collection": 'taxii.content',
+        "auto_create_index": False,
         "crits_type": 'TAXIIContent',
         "latest_schema_version": 2,
         #NOTE: minify_defaults fields should match the MongoEngine field names, NOT the database fields


### PR DESCRIPTION
mongoengine bug #1446 (pymongo3.4 don't have ensure_index, so a create_index request is actually send to the mongodb server before every save done by mongoengine). Solution is to handle index creation manually and disable it in mongoengine with meta = {...,auto_create_index: False}

Taxii service needed this fix.