### PR TITLE
Updated templates for Django 1.9+

### DIFF
--- a/taxii_service/templates/stix_upload_form.html
+++ b/taxii_service/templates/stix_upload_form.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load url from future %}
 
 {% block content %}
 

--- a/taxii_service/templates/taxii_agent_form.html
+++ b/taxii_service/templates/taxii_agent_form.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load url from future %}
 
 {% block content %}
 

--- a/taxii_service/templates/taxii_agent_preview.html
+++ b/taxii_service/templates/taxii_agent_preview.html
@@ -1,5 +1,3 @@
-{% load url from future %}
-
 {% block content %}
 
 <div style="text-align: center; padding-bottom: 10px; margin-top: 15px;">

--- a/taxii_service/templates/taxii_saved_polls.html
+++ b/taxii_service/templates/taxii_saved_polls.html
@@ -1,5 +1,3 @@
-{% load url from future %}
-
 {% block content %}
 
 


### PR DESCRIPTION
This PR updates 4 of the template files to remove {% load url from future %} from the top of each file which was causing a crash.  I found that this statement is no longer required in Django 1.9 and above.