### PR TITLE
VT Download: Add missing return statement

### DIFF
--- a/virustotal_download_service/__init__.py
+++ b/virustotal_download_service/__init__.py
@@ -180,6 +180,7 @@ class VirusTotalDownloadService(Service):
                 self._add_result("Download Canceled", "CRITs was forbidden from downloading the binary.")
             else:
                 self._error("An HTTP Error occurred: {0}".format(e))
+            return
         except Exception as e:
             logger.error("VirusTotal: Failed connection ({0})".format(e))
             self._error("Failed to get data from VirusTotal: {0}".format(e))


### PR DESCRIPTION
Oops.  If an error occurs, or a match is not found, the function should return.
This prevents the `local variable 'data' referenced before assignment` error.