### PR TITLE
Fix path verification for socket in clamd service

### DIFF
--- a/clamd_service/__init__.py
+++ b/clamd_service/__init__.py
@@ -50,8 +50,9 @@ class clamdService(Service):
             raise ServiceConfigError("Socket path or hostname required.")
 
         # If socket is provided check it exists.
-        if not os.path.exists(clamd_sock_path):
-            raise ServiceConfigError('Socket path not found.')
+        if clamd_sock_path:
+            if not os.path.exists(clamd_sock_path):
+                raise ServiceConfigError('Socket path not found.')
 
     @staticmethod
     def get_config_details(config):


### PR DESCRIPTION
There is a simple bug that manifests itself when an empty path is specified for the sock, an exception is thrown, it prevents one from using network socket based service.